### PR TITLE
Add Dependencies category and save on exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A beautiful, user-friendly application for building and managing Valheim modlist
   - **Skills & Progression**: Runescape-style skills, professions system, attribute/level systems, build diversity
   - **Gear & Customization**: New armor/weapon sets, cosmetic items, tameable pets, appearance customization
   - **Co-op Stability**: Server optimization, multiplayer stability, anti-cheat measures
+  - **Dependencies**: Core frameworks or libraries required by other mods
   - **Doesn't Fit**: Other mods
 - **Add mod details** including name, author, and description
 - **View mods by category** with a clean, organized display
@@ -153,6 +154,7 @@ Your modlist data is automatically saved to `modlist_data.json` in the same dire
 - **Skills & Progression**: Detects skill, progression, level, profession, farming, attribute, runescape keywords
 - **Gear & Customization**: Detects gear, armor, weapon, set, cosmetic, appearance, customization, pet keywords
 - **Co-op Stability**: Detects server, multiplayer, coop, stability, dedicated, anti-cheat, performance keywords
+- **Dependencies**: Detects frameworks, library packs, or required base mods
 
 ## Troubleshooting
 

--- a/valheim_modlist_builder.py
+++ b/valheim_modlist_builder.py
@@ -86,6 +86,7 @@ class LMStudioIntegration:
             - Gear & Customization: Armor, weapons, cosmetics
             - Co-op Stability: Server, multiplayer, stability
         - Quality of Life: Inventory, UI, automation, building, navigation, and other improvements that reduce tedium.
+        - Dependencies: Frameworks, libraries, or required base mods
             Respond with ONLY the category name.
             """
         return self._call_model(model, system_prompt, user_prompt, max_tokens=30, temperature=0.2).strip()
@@ -142,7 +143,7 @@ class LMStudioIntegration:
         if code_blocks:
             code_detected = True
             code_snippet = '\n\n'.join(code_blocks)
-            else:
+        else:
             # Check for common code keywords
             code_keywords = ['def ', 'class ', 'public ', 'private ', 'using ', 'namespace ', 'import ', 'void ', 'function ', 'return ', 'if(', 'for(', 'while(', 'try:', 'except', 'catch(', 'System.', 'Console.']
             if any(kw in user_prompt for kw in code_keywords):
@@ -194,6 +195,8 @@ class ValheimModlistBuilder:
             "skills_progression": [],
             "gear_customization": [],
             "coop_stability": [],
+            "quality_of_life": [],
+            "dependencies": [],
             "doesnt_fit": []
         }
         
@@ -208,6 +211,7 @@ class ValheimModlistBuilder:
         self.load_analyzed_mods()
         self.setup_ui()
         self.load_data()
+        self.root.protocol("WM_DELETE_WINDOW", self.on_close)
     
     def setup_ui(self):
         self.create_add_mod_tab()
@@ -348,6 +352,7 @@ class ValheimModlistBuilder:
             ("Gear & Customization", "gear_customization"),
             ("Co-op Stability", "coop_stability"),
             ("Quality of Life", "quality_of_life"),
+            ("Dependencies", "dependencies"),
             ("Doesn't Fit", "doesnt_fit")
         ]
         
@@ -583,12 +588,13 @@ class ValheimModlistBuilder:
         self.filter_category_var = tk.StringVar(value="All Categories")
         categories = ["All Categories"] + [
             "Boss & Combat Overhaul",
-            "Loot Overhaul", 
+            "Loot Overhaul",
             "Magic & Classes",
             "Skills & Progression",
             "Gear & Customization",
             "Co-op Stability",
             "Quality of Life",
+            "Dependencies",
             "Doesn't Fit"
         ]
         
@@ -924,6 +930,7 @@ class ValheimModlistBuilder:
             ("Gear & Customization", "gear_customization"),
             ("Co-op Stability", "coop_stability"),
             ("Quality of Life", "quality_of_life"),
+            ("Dependencies", "dependencies"),
             ("Doesn't Fit", "doesnt_fit")
         ]
         
@@ -1116,6 +1123,7 @@ class ValheimModlistBuilder:
             "Gear & Customization": "gear_customization",
             "Co-op Stability": "coop_stability",
             "Quality of Life": "quality_of_life",
+            "Dependencies": "dependencies",
             "Doesn't Fit": "doesnt_fit"
         }
         
@@ -1195,6 +1203,7 @@ class ValheimModlistBuilder:
                 "Gear & Customization": "gear_customization",
                 "Co-op Stability": "coop_stability",
                 "Quality of Life": "quality_of_life",
+                "Dependencies": "dependencies",
                 "Doesn't Fit": "doesnt_fit",
                 "Doesnt Fit": "doesnt_fit"
             }
@@ -1244,7 +1253,8 @@ class ValheimModlistBuilder:
             "skills_progression": 0,
             "gear_customization": 0,
             "coop_stability": 0,
-            "quality_of_life": 0
+            "quality_of_life": 0,
+            "dependencies": 0
         }
         
         # Boss & Combat Overhaul keywords
@@ -1310,6 +1320,12 @@ class ValheimModlistBuilder:
             'quality', 'life', 'qol', 'convenience', 'ease', 'simplify',
             'automate', 'auto', 'smart', 'intelligent', 'helper', 'assistant'
         ]
+
+        # Dependencies keywords
+        dep_keywords = [
+            'bepinex', 'framework', 'library', 'api', 'dependency', 'hook',
+            'patcher', 'modding framework', 'core mod', 'required'
+        ]
         
         # Check each category
         categories_to_check = [
@@ -1319,7 +1335,8 @@ class ValheimModlistBuilder:
             (skills_keywords, "skills_progression"),
             (gear_keywords, "gear_customization"),
             (coop_keywords, "coop_stability"),
-            (qol_keywords, "quality_of_life")
+            (qol_keywords, "quality_of_life"),
+            (dep_keywords, "dependencies")
         ]
         
         for keywords, category in categories_to_check:
@@ -2099,6 +2116,19 @@ class ValheimModlistBuilder:
             if os.path.exists('modlist_data.json'):
                 with open('modlist_data.json', 'r', encoding='utf-8') as f:
                     self.mods_data = json.load(f)
+            # Ensure all category keys exist after loading
+            for key in [
+                "boss_combat_overhaul",
+                "loot_overhaul",
+                "magic_classes",
+                "skills_progression",
+                "gear_customization",
+                "coop_stability",
+                "quality_of_life",
+                "dependencies",
+                "doesnt_fit",
+            ]:
+                self.mods_data.setdefault(key, [])
         except Exception as e:
             messagebox.showerror("Error", f"Failed to load data: {str(e)}")
     
@@ -2575,6 +2605,15 @@ class ValheimModlistBuilder:
                 for master_mod, files in overlaps:
                     text.insert(tk.END, f"  Conflicts with: {master_mod}\n    Overlapping files: {', '.join(files)}\n")
         tk.Button(popup, text="Close", command=popup.destroy, bg=self.colors['accent'], fg=self.colors['button_fg'], font=("Arial", 10, "bold"), relief=tk.FLAT, bd=0, padx=10, pady=5).pack(pady=10)
+
+    def on_close(self):
+        """Handle application close event by persisting data"""
+        try:
+            self.save_data()
+            self.save_analyzed_mods()
+            self.save_feedback()
+        finally:
+            self.root.destroy()
 
 def main():
     root = tk.Tk()


### PR DESCRIPTION
## Summary
- add missing `quality_of_life` bucket and new `dependencies` category
- update widgets, filtering and auto categorization for the new category
- ensure all categories are present when loading data
- persist data on window close
- document the new category in README

## Testing
- `python -m py_compile valheim_modlist_builder.py`
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: no matching distribution for tkinter)*

------
https://chatgpt.com/codex/tasks/task_e_6875668eaf408331831f55f1a3105e78