### PR TITLE
Add gameplay change sorting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A beautiful, user-friendly application for building and managing Valheim modlist
 - **View mods by category** with a clean, organized display
 - **Delete mods** from your list
 - **Auto-categorization** based on intelligent content analysis
+- **Sort and filter mods** by name, author, category, or gameplay change
 
 ### 📁 Mod Analysis
 - **Upload zip files** containing Valheim mods

--- a/valheim_modlist_builder.py
+++ b/valheim_modlist_builder.py
@@ -614,7 +614,7 @@ class ValheimModlistBuilder:
         # Sort options
         tk.Label(filters_frame, text="Sort by:", bg=self.colors['bg'], fg=self.colors['fg']).pack(anchor=tk.W, pady=(10, 5))
         self.sort_var = tk.StringVar(value="Name")
-        sort_options = ["Name", "Author", "Category", "Date Added"]
+        sort_options = ["Name", "Author", "Category", "Gameplay Change", "Date Added"]
         
         for option in sort_options:
             tk.Radiobutton(
@@ -828,6 +828,18 @@ class ValheimModlistBuilder:
             filtered_mods.sort(key=lambda x: x['author'])
         elif sort_by == "Category":
             filtered_mods.sort(key=lambda x: x['category'])
+        elif sort_by == "Gameplay Change":
+            category_order = {
+                "boss_combat_overhaul": 1,
+                "loot_overhaul": 2,
+                "magic_classes": 3,
+                "skills_progression": 4,
+                "gear_customization": 5,
+                "coop_stability": 6,
+                "quality_of_life": 7,
+                "doesnt_fit": 8
+            }
+            filtered_mods.sort(key=lambda x: category_order.get(x['category_key'], 99))
         
         # Update author combo
         authors = list(set([mod['author'] for mod in all_mods]))


### PR DESCRIPTION
## Summary
- add ability to sort the master mod list by gameplay change
- mention sorting and filtering in README

## Testing
- `python -m py_compile valheim_modlist_builder.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_687568b25b6883318b2158c41364e9e6