### PR TITLE
Disable debug logging and YAML watcher

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.WackysDatabase.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.WackysDatabase.cfg
@@ -35,7 +35,7 @@ NexusModID = 1825
 ## Enable debug logs [Not Synced with Server]
 # Setting type: Boolean
 # Default value: true
-IsDebug = true
+IsDebug = false
 
 ## Do You want to see the String Debug Log - extra logs [Synced with Server]
 # Setting type: Boolean
@@ -65,5 +65,5 @@ ExtraSecurity on Servers = true
 ## EnableYMLWatcher Servers/Singleplayer, YMLs will autoreload if Wackydatabase folder changes(created,renamed,edited) - disable for some servers that auto reload too much [Synced with Server]
 # Setting type: Boolean
 # Default value: true
-FileWatcher for YMLs = true
+FileWatcher for YMLs = false
 


### PR DESCRIPTION
## Summary
- disable debug logging and YAML file watcher for WackyMole database config to reduce log noise and startup overhead

## Testing
- `pytest`
- `./valheim` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_688e4decad1c83319d84b0b966726157