### PR TITLE
Use biome-specific treasure loot sets for RelicHeim chests

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -119,6 +119,11 @@ Valheim/profiles/Dogeheim_Player/BepInEx/config/
 - **Solution**: Created comprehensive clarification table and progression flow
 - **Result**: Clear understanding of 4 distinct legendary systems
 
+### **Biome-Specific Treasure Loot**
+- **Problem**: Generic MagicMaterials set used across all chests limited biome-based progression
+- **Solution**: Replaced chest loot with biome-specific sets and boosted legendary/mythic weights for late biomes
+- **Result**: Higher-tier chests now provide proportionally better materials
+
 ## 🚨 Current Pain Points
 
 ### **Technical Challenges**

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/EpicLoot/patches/RelicHeimPatches/zLootables_TreasureLoot_RelicHeim.json
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/EpicLoot/patches/RelicHeimPatches/zLootables_TreasureLoot_RelicHeim.json
@@ -83,57 +83,57 @@
 	  { "Item": "MaterialsF", "Weight": 0.3}
 	 ]
 	},
-	{
+        {
       "Name": "HaldorChestSwamp",
       "Loot": [
-	  { "Item": "MaterialsA", "Weight": 3},
-	  { "Item": "MaterialsB", "Weight": 2.5},
-	  { "Item": "MaterialsC", "Weight": 3},
-	  { "Item": "MaterialsD", "Weight": 1},
-	  { "Item": "MaterialsF", "Weight": 0.5}
-	 ]
-	},
-	{
+          { "Item": "MaterialsA", "Weight": 3},
+          { "Item": "MaterialsB", "Weight": 2.5},
+          { "Item": "MaterialsC", "Weight": 3},
+          { "Item": "MaterialsD", "Weight": 1.2},
+          { "Item": "MaterialsF", "Weight": 0.7}
+         ]
+        },
+        {
       "Name": "HaldorChestMountain",
       "Loot": [
-	  { "Item": "MaterialsA", "Weight": 2},
-	  { "Item": "MaterialsB", "Weight": 2.5},
-	  { "Item": "MaterialsC", "Weight": 4},
-	  { "Item": "MaterialsD", "Weight": 1},
-	  { "Item": "MaterialsF", "Weight": 0.5}
-	 ]
-	},
-	{
+          { "Item": "MaterialsA", "Weight": 2},
+          { "Item": "MaterialsB", "Weight": 2.5},
+          { "Item": "MaterialsC", "Weight": 4},
+          { "Item": "MaterialsD", "Weight": 1.2},
+          { "Item": "MaterialsF", "Weight": 0.8}
+         ]
+        },
+        {
       "Name": "HaldorChestPlains",
       "Loot": [
-	  { "Item": "MaterialsA", "Weight": 1.5},
-	  { "Item": "MaterialsB", "Weight": 2},
-	  { "Item": "MaterialsC", "Weight": 4.5},
-	  { "Item": "MaterialsD", "Weight": 1.5},
-	  { "Item": "MaterialsF", "Weight": 0.5}
-	 ]
-	},
-	{
+          { "Item": "MaterialsA", "Weight": 1.5},
+          { "Item": "MaterialsB", "Weight": 2},
+          { "Item": "MaterialsC", "Weight": 4},
+          { "Item": "MaterialsD", "Weight": 2},
+          { "Item": "MaterialsF", "Weight": 1}
+         ]
+        },
+        {
       "Name": "HaldorChestMistlands",
       "Loot": [
-	  { "Item": "MaterialsA", "Weight": 1},
-	  { "Item": "MaterialsB", "Weight": 1.5},
-	  { "Item": "MaterialsC", "Weight": 5},
-	  { "Item": "MaterialsD", "Weight": 1.5},
-	  { "Item": "MaterialsF", "Weight": 1}
-	 ]
-	},
-	{
+          { "Item": "MaterialsA", "Weight": 0.5},
+          { "Item": "MaterialsB", "Weight": 1},
+          { "Item": "MaterialsC", "Weight": 3.5},
+          { "Item": "MaterialsD", "Weight": 2.5},
+          { "Item": "MaterialsF", "Weight": 2}
+         ]
+        },
+        {
       "Name": "HaldorChestAshDeep",
       "Loot": [
-	  { "Item": "MaterialsA", "Weight": 0.5},
-	  { "Item": "MaterialsB", "Weight": 1},
-	  { "Item": "MaterialsC", "Weight": 5.5},
-	  { "Item": "MaterialsD", "Weight": 1.5},
-	  { "Item": "MaterialsF", "Weight": 1.5}
+          { "Item": "MaterialsA", "Weight": 0.2},
+          { "Item": "MaterialsB", "Weight": 0.5},
+          { "Item": "MaterialsC", "Weight": 3},
+          { "Item": "MaterialsD", "Weight": 3},
+          { "Item": "MaterialsF", "Weight": 3}
        ]
-	  }
-	 ]
+          }
+         ]
     },
 	
 	{
@@ -142,12 +142,12 @@
       "Value": [ [0, 30], [1, 50], [2, 15], [3, 5] ]
     },
 	{
-	  "Path": "$.LootTables[?(@.Object == 'TreasureChest_meadows')].Loot",
-	  "Action": "Overwrite",
-	  "Value": [
-		{ "Item": "MagicMaterials"}
-	  ]
-	},
+          "Path": "$.LootTables[?(@.Object == 'TreasureChest_meadows')].Loot",
+          "Action": "Overwrite",
+          "Value": [
+                { "Item": "HaldorChestMeadows"}
+          ]
+        },
 	
 	{
       "Path": "$.LootTables[?(@.Object == 'TreasureChest_blackforest')].Drops",
@@ -155,12 +155,12 @@
       "Value": [ [0, 30], [1, 50], [2, 15], [3, 5] ]
     },
 	{
-	  "Path": "$.LootTables[?(@.Object == 'TreasureChest_blackforest')].Loot",
-	  "Action": "Overwrite",
-	  "Value": [
-		{ "Item": "MagicMaterials"}
-	  ]
-	},
+          "Path": "$.LootTables[?(@.Object == 'TreasureChest_blackforest')].Loot",
+          "Action": "Overwrite",
+          "Value": [
+                { "Item": "HaldorChestBlackForest"}
+          ]
+        },
 	
 	{
       "Path": "$.LootTables[?(@.Object == 'TreasureChest_forestcrypt')].Drops",
@@ -168,12 +168,12 @@
       "Value": [ [0, 30], [1, 50], [2, 15], [3, 5] ]
     },
 	{
-	  "Path": "$.LootTables[?(@.Object == 'TreasureChest_forestcrypt')].Loot",
-	  "Action": "Overwrite",
-	  "Value": [
-		{ "Item": "MagicMaterials"}
-	  ]
-	},
+          "Path": "$.LootTables[?(@.Object == 'TreasureChest_forestcrypt')].Loot",
+          "Action": "Overwrite",
+          "Value": [
+                { "Item": "HaldorChestBlackForest"}
+          ]
+        },
 	
 	{
       "Path": "$.LootTables[?(@.Object == 'TreasureChest_fCrypt')].Drops",
@@ -181,12 +181,12 @@
       "Value": [ [0, 30], [1, 50], [2, 15], [3, 5] ]
     },
 	{
-	  "Path": "$.LootTables[?(@.Object == 'TreasureChest_fCrypt')].Loot",
-	  "Action": "Overwrite",
-	  "Value": [
-		{ "Item": "MagicMaterials"}
-	  ]
-	},
+          "Path": "$.LootTables[?(@.Object == 'TreasureChest_fCrypt')].Loot",
+          "Action": "Overwrite",
+          "Value": [
+                { "Item": "HaldorChestBlackForest"}
+          ]
+        },
 	
 	{
       "Path": "$.LootTables[?(@.Object == 'TreasureChest_trollcave')].Drops",
@@ -194,12 +194,12 @@
       "Value": [ [0, 30], [1, 50], [2, 15], [3, 5] ]
     },
 	{
-	  "Path": "$.LootTables[?(@.Object == 'TreasureChest_trollcave')].Loot",
-	  "Action": "Overwrite",
-	  "Value": [
-		{ "Item": "MagicMaterials"}
-	  ]
-	},
+          "Path": "$.LootTables[?(@.Object == 'TreasureChest_trollcave')].Loot",
+          "Action": "Overwrite",
+          "Value": [
+                { "Item": "HaldorChestBlackForest"}
+          ]
+        },
 	
 	{
       "Path": "$.LootTables[?(@.Object == 'shipwreck_karve_chest')].Drops",
@@ -207,12 +207,12 @@
       "Value": [ [0, 30], [1, 50], [2, 15], [3, 5] ]
     },
 	{
-	  "Path": "$.LootTables[?(@.Object == 'shipwreck_karve_chest')].Loot",
-	  "Action": "Overwrite",
-	  "Value": [
-		{ "Item": "MagicMaterials"}
-	  ]
-	},
+          "Path": "$.LootTables[?(@.Object == 'shipwreck_karve_chest')].Loot",
+          "Action": "Overwrite",
+          "Value": [
+                { "Item": "HaldorChestMeadows"}
+          ]
+        },
 	
 	{
       "Path": "$.LootTables[?(@.Object == 'TreasureChest_meadows_buried')].Drops",
@@ -220,12 +220,12 @@
       "Value": [ [0, 30], [1, 50], [2, 15], [3, 5] ]
     },
 	{
-	  "Path": "$.LootTables[?(@.Object == 'TreasureChest_meadows_buried')].Loot",
-	  "Action": "Overwrite",
-	  "Value": [
-		{ "Item": "MagicMaterials"}
-	  ]
-	},
+          "Path": "$.LootTables[?(@.Object == 'TreasureChest_meadows_buried')].Loot",
+          "Action": "Overwrite",
+          "Value": [
+                { "Item": "HaldorChestMeadows"}
+          ]
+        },
 	
 	{
       "Path": "$.LootTables[?(@.Object == 'TreasureChest_sunkencrypt')].Drops",
@@ -233,12 +233,12 @@
       "Value": [ [0, 30], [1, 50], [2, 15], [3, 5] ]
     },
 	{
-	  "Path": "$.LootTables[?(@.Object == 'TreasureChest_sunkencrypt')].Loot",
-	  "Action": "Overwrite",
-	  "Value": [
-		{ "Item": "MagicMaterials"}
-	  ]
-	},
+          "Path": "$.LootTables[?(@.Object == 'TreasureChest_sunkencrypt')].Loot",
+          "Action": "Overwrite",
+          "Value": [
+                { "Item": "HaldorChestSwamp"}
+          ]
+        },
 	
 	{
       "Path": "$.LootTables[?(@.Object == 'TreasureChest_swamp')].Drops",
@@ -246,12 +246,12 @@
       "Value": [ [0, 30], [1, 50], [2, 15], [3, 5] ]
     },
 	{
-	  "Path": "$.LootTables[?(@.Object == 'TreasureChest_swamp')].Loot",
-	  "Action": "Overwrite",
-	  "Value": [
-		{ "Item": "MagicMaterials"}
-	  ]
-	},
+          "Path": "$.LootTables[?(@.Object == 'TreasureChest_swamp')].Loot",
+          "Action": "Overwrite",
+          "Value": [
+                { "Item": "HaldorChestSwamp"}
+          ]
+        },
 	
 	{
       "Path": "$.LootTables[?(@.Object == 'TreasureChest_mountains')].Drops",
@@ -259,12 +259,12 @@
       "Value": [ [0, 30], [1, 50], [2, 15], [3, 5] ]
     },
 	{
-	  "Path": "$.LootTables[?(@.Object == 'TreasureChest_mountains')].Loot",
-	  "Action": "Overwrite",
-	  "Value": [
-		{ "Item": "MagicMaterials"}
-	  ]
-	},
+          "Path": "$.LootTables[?(@.Object == 'TreasureChest_mountains')].Loot",
+          "Action": "Overwrite",
+          "Value": [
+                { "Item": "HaldorChestMountain"}
+          ]
+        },
 	
 	{
       "Path": "$.LootTables[?(@.Object == 'TreasureChest_mountaincave')].Drops",
@@ -272,12 +272,12 @@
       "Value": [ [0, 30], [1, 50], [2, 15], [3, 5] ]
     },
 	{
-	  "Path": "$.LootTables[?(@.Object == 'TreasureChest_mountaincave')].Loot",
-	  "Action": "Overwrite",
-	  "Value": [
-		{ "Item": "MagicMaterials"}
-	  ]
-	},
+          "Path": "$.LootTables[?(@.Object == 'TreasureChest_mountaincave')].Loot",
+          "Action": "Overwrite",
+          "Value": [
+                { "Item": "HaldorChestMountain"}
+          ]
+        },
 	
 	{
       "Path": "$.LootTables[?(@.Object == 'TreasureChest_plains_stone')].Drops",
@@ -285,12 +285,12 @@
       "Value": [ [0, 30], [1, 50], [2, 15], [3, 5] ]
     },
 	{
-	  "Path": "$.LootTables[?(@.Object == 'TreasureChest_plains_stone')].Loot",
-	  "Action": "Overwrite",
-	  "Value": [
-		{ "Item": "MagicMaterials"}
-	  ]
-	},
+          "Path": "$.LootTables[?(@.Object == 'TreasureChest_plains_stone')].Loot",
+          "Action": "Overwrite",
+          "Value": [
+                { "Item": "HaldorChestPlains"}
+          ]
+        },
 	
 	{
       "Path": "$.LootTables[?(@.Object == 'TreasureChest_heath')].Drops",
@@ -298,12 +298,12 @@
       "Value": [ [0, 30], [1, 50], [2, 15], [3, 5] ]
     },
 	{
-	  "Path": "$.LootTables[?(@.Object == 'TreasureChest_heath')].Loot",
-	  "Action": "Overwrite",
-	  "Value": [
-		{ "Item": "MagicMaterials"}
-	  ]
-	},
+          "Path": "$.LootTables[?(@.Object == 'TreasureChest_heath')].Loot",
+          "Action": "Overwrite",
+          "Value": [
+                { "Item": "HaldorChestPlains"}
+          ]
+        },
 	
 	{
       "Path": "$.LootTables[?(@.Object == 'TreasureChest_dvergrtown')].Drops",
@@ -311,12 +311,12 @@
       "Value": [ [0, 30], [1, 50], [2, 15], [3, 5] ]
     },
 	{
-	  "Path": "$.LootTables[?(@.Object == 'TreasureChest_dvergrtown')].Loot",
-	  "Action": "Overwrite",
-	  "Value": [
-		{ "Item": "MagicMaterials"}
-	  ]
-	},
+          "Path": "$.LootTables[?(@.Object == 'TreasureChest_dvergrtown')].Loot",
+          "Action": "Overwrite",
+          "Value": [
+                { "Item": "HaldorChestMistlands"}
+          ]
+        },
 	
 	{
       "Path": "$.LootTables[?(@.Object == 'TreasureChest_dvergrtower')].Drops",
@@ -324,12 +324,12 @@
       "Value": [ [0, 30], [1, 50], [2, 15], [3, 5] ]
     },
 	{
-	  "Path": "$.LootTables[?(@.Object == 'TreasureChest_dvergrtower')].Loot",
-	  "Action": "Overwrite",
-	  "Value": [
-		{ "Item": "MagicMaterials"}
-	  ]
-	},
+          "Path": "$.LootTables[?(@.Object == 'TreasureChest_dvergrtower')].Loot",
+          "Action": "Overwrite",
+          "Value": [
+                { "Item": "HaldorChestMistlands"}
+          ]
+        },
 	
 	{
       "Path": "$.LootTables[?(@.Object == 'TreasureChest_dvergr_loose_stone')].Drops",
@@ -337,12 +337,12 @@
       "Value": [ [0, 30], [1, 50], [2, 15], [3, 5] ]
     },
 	{
-	  "Path": "$.LootTables[?(@.Object == 'TreasureChest_dvergr_loose_stone')].Loot",
-	  "Action": "Overwrite",
-	  "Value": [
-		{ "Item": "MagicMaterials"}
-	  ]
-	},
+          "Path": "$.LootTables[?(@.Object == 'TreasureChest_dvergr_loose_stone')].Loot",
+          "Action": "Overwrite",
+          "Value": [
+                { "Item": "HaldorChestMistlands"}
+          ]
+        },
 	
 	{
       "Path": "$.LootTables[?(@.Object == 'TreasureChest_charredfortress')].Drops",
@@ -350,12 +350,12 @@
       "Value": [ [0, 30], [1, 50], [2, 15], [3, 5] ]
     },
 	{
-	  "Path": "$.LootTables[?(@.Object == 'TreasureChest_charredfortress')].Loot",
-	  "Action": "Overwrite",
-	  "Value": [
-		{ "Item": "MagicMaterials"}
-	  ]
-	},
+          "Path": "$.LootTables[?(@.Object == 'TreasureChest_charredfortress')].Loot",
+          "Action": "Overwrite",
+          "Value": [
+                { "Item": "HaldorChestAshDeep"}
+          ]
+        },
 	
 	{
       "Path": "$.LootTables[?(@.Object == 'TreasureChest_ashland_stone')].Drops",
@@ -363,12 +363,12 @@
       "Value": [ [0, 30], [1, 50], [2, 15], [3, 5] ]
     },
 	{
-	  "Path": "$.LootTables[?(@.Object == 'TreasureChest_ashland_stone')].Loot",
-	  "Action": "Overwrite",
-	  "Value": [
-		{ "Item": "MagicMaterials"}
-	  ]
-	},
+          "Path": "$.LootTables[?(@.Object == 'TreasureChest_ashland_stone')].Loot",
+          "Action": "Overwrite",
+          "Value": [
+                { "Item": "HaldorChestAshDeep"}
+          ]
+        },
 	
 	{
 	  "Path": "$.LootTables[?(@.Object == 'TreasureMapChest_Meadows')].Loot",


### PR DESCRIPTION
## Summary
- Scale treasure loot by biome using HaldorChest sets instead of a generic MagicMaterials pool
- Boost legendary and mythic material weights in late-biome chests
- Document loot-table update in AGENTS memory

## Testing
- `jq . Valheim/profiles/Dogeheim_Player/BepInEx/config/EpicLoot/patches/RelicHeimPatches/zLootables_TreasureLoot_RelicHeim.json`

------
https://chatgpt.com/codex/tasks/task_e_688e50f4de1083319cc72e97bdb8821d