### PR TITLE
fix: correct AxeSilver prefab in More World Locations

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -183,6 +183,11 @@ Valheim/profiles/Dogeheim_Player/BepInEx/config/
 - **Solution**: Added validation in `generate_loot_configs.py` to detect duplicates and abort generation
 - **Result**: Prevents accidental probability stacking during loot config creation
 
+### **AxeSilver Prefab Error**
+- **Problem**: More World Locations loot lists referenced `AxeSilver` causing prefab errors.
+- **Solution**: Replaced with `AxeSilver_TW` to match modded prefab.
+- **Result**: AxeSilver loot lists load without errors.
+
 ## 🚨 Current Pain Points
 
 ### **Technical Challenges**

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.More_World_Locations_LootLists.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.More_World_Locations_LootLists.yml
@@ -1372,7 +1372,7 @@ BlackforestLoot3:
     stackMax: 2
     weight: 0.8
   # Silver tier weapons and tools
-  - item: AxeSilver
+  - item: AxeSilver_TW
     stackMin: 1
     stackMax: 1
     weight: 0.4
@@ -3059,7 +3059,7 @@ MountainsLoot1:
     stackMax: 2
     weight: 1.0
   # Silver tier weapons and tools
-  - item: AxeSilver
+  - item: AxeSilver_TW
     stackMin: 1
     stackMax: 1
     weight: 0.8


### PR DESCRIPTION
## Summary
- fix misreferenced AxeSilver prefab in More World Locations loot lists
- note AxeSilver prefab fix in AGENTS memory

## Testing
- `python Valheim_Help_Docs/List_Important_files.py both`


------
https://chatgpt.com/codex/tasks/task_e_688ebe79d77083318beb047cc9138944