### PR TITLE
Increase Mushroom Monsters spawn rates

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -195,6 +195,7 @@ Valheim/profiles/Dogeheim_Player/BepInEx/config/
 - Balance magic vs static loot drop rates
 - Ensure boss-locked BiS items feel worth the grind
 - Streamline AI → config → game pipeline
+- Monitor increased Mushroom Monster spawn rates across biomes for balance
 
 ## 💡 Loot System Ideas / TODO
 - Introduce boss-specific unique drops with rare rates and signature effects.

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
@@ -8,3 +8,83 @@
 #     4. Make your changes.
 # To find modded configs and change those, enable WriteSpawnTablesToFileAfterChanges in 'spawn_that.cfg', and do as described above.
 
+[WorldSpawner.666]
+Name = Mushroom Meadows
+PrefabName = MushroomMeadows_MP
+Biomes = Meadows
+Enabled = true
+MaxSpawned = 2
+SpawnInterval = 300
+SpawnChance = 30
+ConditionDistanceToCenterMin = 500
+
+[WorldSpawner.667]
+Name = Mushroom Forest
+PrefabName = MushroomForest_MP
+Biomes = BlackForest
+Enabled = true
+MaxSpawned = 2
+SpawnInterval = 300
+SpawnChance = 30
+ConditionDistanceToCenterMin = 500
+
+[WorldSpawner.668]
+Name = Mushroom Swamp
+PrefabName = MushroomSwamp_MP
+Biomes = Swamp
+Enabled = true
+MaxSpawned = 2
+SpawnInterval = 300
+SpawnChance = 30
+ConditionDistanceToCenterMin = 500
+
+[WorldSpawner.669]
+Name = Mushroom Mountain
+PrefabName = MushroomMountain_MP
+Biomes = Mountain
+Enabled = true
+MaxSpawned = 2
+SpawnInterval = 300
+SpawnChance = 30
+ConditionDistanceToCenterMin = 500
+
+[WorldSpawner.670]
+Name = Mushroom Plains
+PrefabName = MushroomPlains_MP
+Biomes = Plains
+Enabled = true
+MaxSpawned = 2
+SpawnInterval = 300
+SpawnChance = 30
+ConditionDistanceToCenterMin = 500
+
+[WorldSpawner.671]
+Name = Mushroom Mistlands
+PrefabName = MushroomMistlands_MP
+Biomes = Mistlands
+Enabled = true
+MaxSpawned = 2
+SpawnInterval = 300
+SpawnChance = 30
+ConditionDistanceToCenterMin = 500
+
+[WorldSpawner.672]
+Name = Mushroom Ashlands
+PrefabName = MushroomAshLands_MP
+Biomes = AshLands
+Enabled = true
+MaxSpawned = 2
+SpawnInterval = 300
+SpawnChance = 30
+ConditionDistanceToCenterMin = 500
+
+[WorldSpawner.673]
+Name = Mushroom Deep North
+PrefabName = MushroomDeepNorth_MP
+Biomes = DeepNorth
+Enabled = true
+MaxSpawned = 2
+SpawnInterval = 300
+SpawnChance = 30
+ConditionDistanceToCenterMin = 500
+


### PR DESCRIPTION
## Summary
- Add Spawn That world spawner entries for all Mushroom Monster variants with slightly higher spawn chances
- Document spawn rate tuning in AGENTS memory

## Testing
- `python Valheim_Help_Docs/List_Important_files.py both`

------
https://chatgpt.com/codex/tasks/task_e_688ebed66c5083319054d14331bbc61d