### PR TITLE
Configure modded creature spawns and loot

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -179,6 +179,11 @@ Valheim/profiles/Dogeheim_Player/BepInEx/config/
 - **Solution**: Updated drop tables to remove zero-roll chance, ensuring a minimum of one item.
 - **Result**: Treasure chests now always yield at least one piece of loot.
 
+### **Mod Creature Drop World Levels**
+- **Problem**: Newly added modded creature loot tables were not yet reviewed for biome/world-level balance.
+- **Solution**: Audited each mod creature drop list to ensure materials match the creature's intended biome (e.g., Fox_TW drops early-game LeatherScraps while CorruptedDvergerMage_TW yields Mistlands BlackCore/Softtissue).
+- **Result**: Mod creature loot tables align with world-level progression.
+
 ### **VNEI Load Performance**
 - **Problem**: VNEI UI loaded slowly with unknown items and recipes visible
 - **Solution**: Enabled "Show Only Known" (server-forced) in com.maxsch.valheim.vnei.cfg

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/drop_that.character_drop.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/drop_that.character_drop.cfg
@@ -8,3 +8,309 @@
 #     4. Make your changes.
 # To find modded configs and change those, enable WriteLoadedConfigsToFile in 'drop_that.cfg', and do as described above.
 
+# Modded creature drops
+[Fox_TW.1]
+PrefabName = LeatherScraps
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 2
+SetChanceToDrop = 0.5
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[Fox_TW.2]
+PrefabName = RawMeat
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 2
+SetChanceToDrop = 1
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[Sheep_TW.1]
+PrefabName = DeerHide
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 2
+SetChanceToDrop = 0.5
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[Sheep_TW.2]
+PrefabName = RawMeat
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 2
+SetChanceToDrop = 1
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[Razorback_TW.1]
+PrefabName = LeatherScraps
+EnableConfig = true
+SetAmountMin = 2
+SetAmountMax = 3
+SetChanceToDrop = 0.75
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[Razorback_TW.2]
+PrefabName = RawMeat
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 2
+SetChanceToDrop = 1
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[BlackBear_TW.1]
+PrefabName = DeerHide
+EnableConfig = true
+SetAmountMin = 2
+SetAmountMax = 3
+SetChanceToDrop = 0.75
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[BlackBear_TW.2]
+PrefabName = RawMeat
+EnableConfig = true
+SetAmountMin = 2
+SetAmountMax = 4
+SetChanceToDrop = 1
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[GDAncientShaman_TW.1]
+PrefabName = GreydwarfEye
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 2
+SetChanceToDrop = 1
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[GDAncientShaman_TW.2]
+PrefabName = Resin
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 2
+SetChanceToDrop = 0.5
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[GreydwarfMage_TW.1]
+PrefabName = GreydwarfEye
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 2
+SetChanceToDrop = 1
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[GreydwarfMage_TW.2]
+PrefabName = Coal
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 2
+SetChanceToDrop = 0.5
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[RottingElk_TW.1]
+PrefabName = Entrails
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 2
+SetChanceToDrop = 1
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[RottingElk_TW.2]
+PrefabName = LeatherScraps
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 2
+SetChanceToDrop = 0.5
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[Crawler_TW.1]
+PrefabName = Chitin
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 2
+SetChanceToDrop = 0.5
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[Crawler_TW.2]
+PrefabName = Coins
+EnableConfig = true
+SetAmountMin = 5
+SetAmountMax = 20
+SetChanceToDrop = 0.2
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[HelWraith_TW.1]
+PrefabName = Chain
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.25
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[HelWraith_TW.2]
+PrefabName = TrophyWraith
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.1
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[SkeletonMage_TW.1]
+PrefabName = BoneFragments
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 3
+SetChanceToDrop = 1
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[SkeletonMage_TW.2]
+PrefabName = Ruby
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.15
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[ObsidianGolem_TW.1]
+PrefabName = Obsidian
+EnableConfig = true
+SetAmountMin = 2
+SetAmountMax = 5
+SetChanceToDrop = 1
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[ObsidianGolem_TW.2]
+PrefabName = Crystal
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 3
+SetChanceToDrop = 0.5
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[GrizzlyBear_TW.1]
+PrefabName = WolfPelt
+EnableConfig = true
+SetAmountMin = 2
+SetAmountMax = 3
+SetChanceToDrop = 0.75
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[GrizzlyBear_TW.2]
+PrefabName = RawMeat
+EnableConfig = true
+SetAmountMin = 2
+SetAmountMax = 4
+SetChanceToDrop = 1
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[FenringMage_TW.1]
+PrefabName = WolfFang
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 2
+SetChanceToDrop = 0.75
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[FenringMage_TW.2]
+PrefabName = FreezeGland
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.5
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[Prowler_TW.1]
+PrefabName = WolfPelt
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 2
+SetChanceToDrop = 0.75
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[Prowler_TW.2]
+PrefabName = Coins
+EnableConfig = true
+SetAmountMin = 10
+SetAmountMax = 30
+SetChanceToDrop = 0.25
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[GoblinMage_TW.1]
+PrefabName = BlackMetalScrap
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 2
+SetChanceToDrop = 0.75
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[GoblinMage_TW.2]
+PrefabName = Coins
+EnableConfig = true
+SetAmountMin = 5
+SetAmountMax = 20
+SetChanceToDrop = 0.5
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[CorruptedDvergerMage_TW.1]
+PrefabName = BlackCore
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.5
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[CorruptedDvergerMage_TW.2]
+PrefabName = Softtissue
+EnableConfig = true
+SetAmountMin = 2
+SetAmountMax = 3
+SetChanceToDrop = 1
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[SummonedSeeker_TW.1]
+PrefabName = Chitin
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 2
+SetChanceToDrop = 0.75
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[SummonedSeeker_TW.2]
+PrefabName = Mandible
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 2
+SetChanceToDrop = 0.5
+SetDropOnePerPlayer = false
+SetScaleByLevel = false

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.simple.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.simple.cfg
@@ -588,3 +588,139 @@ GroupSizeMaxMultiplier = 1
 # Higher means more often. 2 is twice as often, 0.5 is double the time between spawn checks.
 SpawnFrequencyMultiplier = 0.95
 
+# Modded creature spawns
+[FOX_TW]
+PrefabName = Fox_TW
+Enable = true
+SpawnMaxMultiplier = 1
+GroupSizeMinMultiplier = 1
+GroupSizeMaxMultiplier = 1
+SpawnFrequencyMultiplier = 0.95
+
+[SHEEP_TW]
+PrefabName = Sheep_TW
+Enable = true
+SpawnMaxMultiplier = 1
+GroupSizeMinMultiplier = 1
+GroupSizeMaxMultiplier = 1
+SpawnFrequencyMultiplier = 0.95
+
+[RAZORBACK_TW]
+PrefabName = Razorback_TW
+Enable = true
+SpawnMaxMultiplier = 1
+GroupSizeMinMultiplier = 1
+GroupSizeMaxMultiplier = 1
+SpawnFrequencyMultiplier = 0.95
+
+[BLACKBEAR_TW]
+PrefabName = BlackBear_TW
+Enable = true
+SpawnMaxMultiplier = 1
+GroupSizeMinMultiplier = 1
+GroupSizeMaxMultiplier = 1
+SpawnFrequencyMultiplier = 0.95
+
+[GDANCIENTSHAMAN_TW]
+PrefabName = GDAncientShaman_TW
+Enable = true
+SpawnMaxMultiplier = 1
+GroupSizeMinMultiplier = 1
+GroupSizeMaxMultiplier = 1
+SpawnFrequencyMultiplier = 0.95
+
+[GREYDORFMAGE_TW]
+PrefabName = GreydwarfMage_TW
+Enable = true
+SpawnMaxMultiplier = 1
+GroupSizeMinMultiplier = 1
+GroupSizeMaxMultiplier = 1
+SpawnFrequencyMultiplier = 0.95
+
+[ROTTINGELK_TW]
+PrefabName = RottingElk_TW
+Enable = true
+SpawnMaxMultiplier = 1
+GroupSizeMinMultiplier = 1
+GroupSizeMaxMultiplier = 1
+SpawnFrequencyMultiplier = 0.95
+
+[CRAWLER_TW]
+PrefabName = Crawler_TW
+Enable = true
+SpawnMaxMultiplier = 1
+GroupSizeMinMultiplier = 1
+GroupSizeMaxMultiplier = 1
+SpawnFrequencyMultiplier = 0.95
+
+[HELWRAITH_TW]
+PrefabName = HelWraith_TW
+Enable = true
+SpawnMaxMultiplier = 1
+GroupSizeMinMultiplier = 1
+GroupSizeMaxMultiplier = 1
+SpawnFrequencyMultiplier = 0.95
+
+[SKELETONMAGE_TW]
+PrefabName = SkeletonMage_TW
+Enable = true
+SpawnMaxMultiplier = 1
+GroupSizeMinMultiplier = 1
+GroupSizeMaxMultiplier = 1
+SpawnFrequencyMultiplier = 0.95
+
+[OBSIDIANGOLEM_TW]
+PrefabName = ObsidianGolem_TW
+Enable = true
+SpawnMaxMultiplier = 1
+GroupSizeMinMultiplier = 1
+GroupSizeMaxMultiplier = 1
+SpawnFrequencyMultiplier = 0.95
+
+[GRIZZLYBEAR_TW]
+PrefabName = GrizzlyBear_TW
+Enable = true
+SpawnMaxMultiplier = 1
+GroupSizeMinMultiplier = 1
+GroupSizeMaxMultiplier = 1
+SpawnFrequencyMultiplier = 0.95
+
+[FENRINGMAGE_TW]
+PrefabName = FenringMage_TW
+Enable = true
+SpawnMaxMultiplier = 1
+GroupSizeMinMultiplier = 1
+GroupSizeMaxMultiplier = 1
+SpawnFrequencyMultiplier = 0.95
+
+[PROWLER_TW]
+PrefabName = Prowler_TW
+Enable = true
+SpawnMaxMultiplier = 1
+GroupSizeMinMultiplier = 1
+GroupSizeMaxMultiplier = 1
+SpawnFrequencyMultiplier = 0.95
+
+[GOBLINMAGE_TW]
+PrefabName = GoblinMage_TW
+Enable = true
+SpawnMaxMultiplier = 1
+GroupSizeMinMultiplier = 1
+GroupSizeMaxMultiplier = 1
+SpawnFrequencyMultiplier = 0.95
+
+[CORRUPTEDDVERGERMAGE_TW]
+PrefabName = CorruptedDvergerMage_TW
+Enable = true
+SpawnMaxMultiplier = 1
+GroupSizeMinMultiplier = 1
+GroupSizeMaxMultiplier = 1
+SpawnFrequencyMultiplier = 0.95
+
+[SUMMONEDSEEKER_TW]
+PrefabName = SummonedSeeker_TW
+Enable = true
+SpawnMaxMultiplier = 1
+GroupSizeMinMultiplier = 1
+GroupSizeMaxMultiplier = 1
+SpawnFrequencyMultiplier = 0.95


### PR DESCRIPTION
## Summary
- Add spawn-that entries so mod creatures spawn at standard world rates
- Define balanced loot tables for modded creatures
- Record world-level loot audit in AGENTS memory

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pre-commit run --files .continue/AGENTS.md Valheim/profiles/Dogeheim_Player/BepInEx/config/drop_that.character_drop.cfg Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.simple.cfg` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ecd57e73c83318dad4518a0e8b979