### PR TITLE
Boost stamina and remove unsupported Dexterity soft cap

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -169,6 +169,11 @@ Valheim/profiles/Dogeheim_Player/BepInEx/config/
 - **Solution**: Created comprehensive clarification table and progression flow
 - **Result**: Clear understanding of 4 distinct legendary systems
 
+### **EpicMMO Dexterity Soft Cap**
+- **Problem**: Added Dexterity stamina soft cap entries were not recognized by EpicMMO System
+- **Solution**: Removed unsupported soft cap settings, keeping base stamina bonuses only
+- **Result**: Prevents non-functional config lines and maintains balanced stamina progression
+
 ### **Biome-Specific Treasure Loot**
 - **Problem**: Generic MagicMaterials set used across all chests limited biome-based progression
 - **Solution**: Replaced chest loot with biome-specific sets and boosted legendary/mythic weights for late biomes

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.EpicMMOSystem.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.EpicMMOSystem.cfg
@@ -179,12 +179,12 @@ StaminaReduction = 0.25
 ## One Point Stamina Increase. [Synced with Server]
 # Setting type: Single
 # Default value: 1
-AddStamina = 1.6
+AddStamina = 1.8
 
 ## Increase stamina regeneration per point. [Synced with Server]
 # Setting type: Single
 # Default value: 0.4
-StaminaReg = 0.65
+StaminaReg = 0.75
 
 ## Increase in physical protection per point. [Synced with Server]
 # Setting type: Single


### PR DESCRIPTION
## Summary
- Increase Endurance's per-point stamina and regeneration for a stronger start
- Remove unrecognized Dexterity stamina soft cap settings while retaining 0.25 stamina bonuses

## Testing
- `python Valheim_Help_Docs/List_Important_files.py both`


------
https://chatgpt.com/codex/tasks/task_e_688f48eefa748331b5704c9e35121f58