### PR TITLE
Add Leech Matron spawn and loot configuration

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -219,6 +219,7 @@ Valheim/profiles/Dogeheim_Player/BepInEx/config/
 - Monitor increased Mushroom Monster spawn rates across biomes for balance
 - Balanced Mushroom boss drops: WL-scaled coins guaranteed, portal key guaranteed, and rare (~5%/1% overall via 2.5%/0.5% per-roll) gold/silver statues per player
 - Maintain progression-based loot tables for Mushroom Monsters (bosses excluded; rare mushrooms drop-one-per-player)
+- Track balance for new Leech Matron swamp spawns (rainy nights, deep water) and expanded loot (ooze, blood pearls, bloodbags, entrails, amber pearls, EpicLoot magic weapon) with lightning infusion visuals
 
 ## 💡 Loot System Ideas / TODO
 - Introduce boss-specific unique drops with rare rates and signature effects.

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/CreatureConfig_Creatures.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/CreatureConfig_Creatures.yml
@@ -86,6 +86,12 @@ Surtling:
  Ashlands:
   health: 15
   health per star: 3
+# New swamp elite
+LeechMatron:
+  health: 10
+  health per star: 5
+  damage: 2
+  damage per star: 1
 #Mountains
 Ulv:
   health: 2.2

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/drop_that.character_drop.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/drop_that.character_drop.cfg
@@ -8,6 +8,110 @@
 #     4. Make your changes.
 # To find modded configs and change those, enable WriteLoadedConfigsToFile in 'drop_that.cfg', and do as described above.
 
+
+# Leech Matron loot
+[Leech.1]
+PrefabName = Ooze
+EnableConfig = true
+SetAmountMin = 2
+SetAmountMax = 4
+SetChanceToDrop = 1
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[Leech.1.SpawnThat]
+ConditionTemplateId = LeechMatron
+
+[Leech.2]
+PrefabName = BloodPearl
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 2
+SetChanceToDrop = 0.25
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[Leech.2.SpawnThat]
+ConditionTemplateId = LeechMatron
+
+[Leech.3]
+PrefabName = ReagentRare
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.05
+SetDropOnePerPlayer = true
+SetScaleByLevel = false
+
+[Leech.3.SpawnThat]
+ConditionTemplateId = LeechMatron
+
+[Leech.4]
+PrefabName = Bloodbag
+EnableConfig = true
+SetAmountMin = 2
+SetAmountMax = 5
+SetChanceToDrop = 0.8
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[Leech.4.SpawnThat]
+ConditionTemplateId = LeechMatron
+
+[Leech.5]
+PrefabName = TrophyLeech
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.5
+SetDropOnePerPlayer = true
+SetScaleByLevel = false
+
+[Leech.5.SpawnThat]
+ConditionTemplateId = LeechMatron
+
+[Leech.6]
+PrefabName = Entrails
+EnableConfig = true
+SetAmountMin = 2
+SetAmountMax = 4
+SetChanceToDrop = 0.5
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[Leech.6.SpawnThat]
+ConditionTemplateId = LeechMatron
+
+[Leech.7]
+PrefabName = AmberPearl
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 2
+SetChanceToDrop = 0.2
+SetDropOnePerPlayer = false
+SetScaleByLevel = false
+
+[Leech.7.SpawnThat]
+ConditionTemplateId = LeechMatron
+
+[Leech.8]
+PrefabName = SwordIron
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.05
+SetDropOnePerPlayer = true
+SetScaleByLevel = false
+
+[Leech.8.SpawnThat]
+ConditionTemplateId = LeechMatron
+
+[Leech.8.EpicLoot]
+RarityWeightMagic = 0
+RarityWeightRare = 100
+RarityWeightEpic = 50
+RarityWeightLegendary = 10
+
 # Modded creature drops
 [Fox_TW.1]
 PrefabName = LeatherScraps

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
@@ -88,3 +88,19 @@ SpawnInterval = 300
 SpawnChance = 30
 ConditionDistanceToCenterMin = 500
 
+[WorldSpawner.674]
+Name = Leech Matron
+PrefabName = Leech
+Biomes = Swamp
+Enabled = true
+Scale = 4
+ConditionEnvironments = Rain
+ConditionTime = Night
+OceanDepthMin = 4
+TemplateId = LeechMatron
+
+[WorldSpawner.674.CreatureLevelAndLootControl]
+SetInfusion=Lightning
+SetExtraEffect=Quick
+SetName=Leech Matron
+


### PR DESCRIPTION
## Summary
- Leech Matron world spawn now uses its own template ID and lightning infusion for a glowing 4×-scaled boss encounter
- Loot table expanded with bloodbags, trophy, entrails, amber pearls, and a rare EpicLoot-enchanted iron sword drop
- AGENTS memory updated to track balance of the Leech Matron’s new loot and visuals

## Testing
- `python Valheim_Help_Docs/List_Important_files.py both`


------
https://chatgpt.com/codex/tasks/task_e_688f4f52242c8331b012328af0d22e4a