### PR TITLE
Add coin-gated Black Forest troll spawn and loot

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -219,6 +219,7 @@ Valheim/profiles/Dogeheim_Player/BepInEx/config/
 - Monitor increased Mushroom Monster spawn rates across biomes for balance
 - Balanced Mushroom boss drops: WL-scaled coins guaranteed, portal key guaranteed, and rare (~5%/1% overall via 2.5%/0.5% per-roll) gold/silver statues per player
 - Maintain progression-based loot tables for Mushroom Monsters (bosses excluded; rare mushrooms drop-one-per-player)
+- Add coin-gated Troll encounter in Black Forest requiring 500+ coins and heavy carry weight; uses separate CoinTroll prefab with boss visuals and WL-based loot: trophy/coins/finewood (WL2), runestone (WL3), iron scrap (WL4), and Yggdrasil wood (WL6+)
 
 ## 💡 Loot System Ideas / TODO
 - Introduce boss-specific unique drops with rare rates and signature effects.

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/drop_that.character_drop.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/drop_that.character_drop.cfg
@@ -314,3 +314,64 @@ SetAmountMax = 2
 SetChanceToDrop = 0.5
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
+
+[CoinTroll.1]
+PrefabName = TrophyTroll
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 1
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+SetWorldLevelMin = 2
+
+[CoinTroll.2]
+PrefabName = Coins
+EnableConfig = true
+SetAmountMin = 250
+SetAmountMax = 500
+SetChanceToDrop = 1
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+SetWorldLevelMin = 2
+
+[CoinTroll.3]
+PrefabName = FineWood
+EnableConfig = true
+SetAmountMin = 10
+SetAmountMax = 20
+SetChanceToDrop = 1
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+SetWorldLevelMin = 2
+
+[CoinTroll.4]
+PrefabName = RunestoneEpic
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 1
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+SetWorldLevelMin = 3
+
+[CoinTroll.5]
+PrefabName = IronScrap
+EnableConfig = true
+SetAmountMin = 5
+SetAmountMax = 10
+SetChanceToDrop = 1
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+SetWorldLevelMin = 4
+
+[CoinTroll.6]
+PrefabName = YggdrasilWood
+EnableConfig = true
+SetAmountMin = 10
+SetAmountMax = 20
+SetChanceToDrop = 1
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+SetWorldLevelMin = 6
+

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
@@ -88,3 +88,15 @@ SpawnInterval = 300
 SpawnChance = 30
 ConditionDistanceToCenterMin = 500
 
+
+[WorldSpawner.674]
+Name = Coin Troll
+PrefabName = CoinTroll
+Biomes = BlackForest
+Enabled = true
+MaxSpawned = 1
+SpawnInterval = 600
+SpawnChance = 1
+ConditionBiome = BlackForest
+ConditionPlayerCarryWeight = 500
+

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/plugins/codex-CoinTrollSpawn/CoinTrollSpawn.cs
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/plugins/codex-CoinTrollSpawn/CoinTrollSpawn.cs
@@ -1,0 +1,94 @@
+using BepInEx;
+using UnityEngine;
+
+using Object = UnityEngine.Object;
+
+namespace CodexMods.CoinTrollSpawn
+{
+    [BepInPlugin("codex.cointrollspawn", "Coin Troll Spawn Hook", "1.0.0")]
+    public class CoinTrollSpawn : BaseUnityPlugin
+    {
+        private Heightmap.Biome _lastBiome = Heightmap.Biome.None;
+        private const int CoinThreshold = 500;
+        private GameObject _coinTrollPrefab;
+
+        private void Start()
+        {
+            RegisterCoinTrollPrefab();
+        }
+
+        private void Update()
+        {
+            if (_coinTrollPrefab == null)
+            {
+                RegisterCoinTrollPrefab();
+            }
+
+            var player = Player.m_localPlayer;
+            if (player == null)
+            {
+                return;
+            }
+
+            var biome = player.GetCurrentBiome();
+            if (biome == _lastBiome)
+            {
+                return;
+            }
+
+            if (biome == Heightmap.Biome.BlackForest && RandEventSystem.instance?.m_activeEvent == null)
+            {
+                int coins = player.GetInventory().CountItems("Coins");
+                if (coins >= CoinThreshold)
+                {
+                    SpawnTrollNearby(player.transform.position);
+                }
+            }
+
+            _lastBiome = biome;
+        }
+
+        private void RegisterCoinTrollPrefab()
+        {
+            var scene = ZNetScene.instance;
+            if (scene == null || _coinTrollPrefab != null)
+            {
+                return;
+            }
+
+            var basePrefab = scene.GetPrefab("Troll");
+            if (basePrefab == null)
+            {
+                return;
+            }
+
+            _coinTrollPrefab = Object.Instantiate(basePrefab);
+            _coinTrollPrefab.name = "CoinTroll";
+            _coinTrollPrefab.transform.localScale *= 1.5f;
+
+            foreach (var renderer in _coinTrollPrefab.GetComponentsInChildren<Renderer>())
+            {
+                var material = new Material(renderer.material);
+                material.color = Color.yellow;
+                renderer.material = material;
+            }
+
+            scene.m_prefabs.Add(_coinTrollPrefab);
+            scene.m_namedPrefabs[_coinTrollPrefab.name.GetHashCode()] = _coinTrollPrefab;
+            _coinTrollPrefab.SetActive(false);
+        }
+
+        private void SpawnTrollNearby(Vector3 position)
+        {
+            if (_coinTrollPrefab == null)
+            {
+                return;
+            }
+
+            Vector3 spawnPos = position + Vector3.forward * 5f;
+            var troll = Instantiate(_coinTrollPrefab, spawnPos, Quaternion.identity);
+            troll.name = "CoinTroll";
+            troll.SetActive(true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Raise coin troll trigger to 500 coins and give spawned troll boss visuals
- Gate troll world spawner by heavy carry weight
- Upgrade troll drops with guaranteed trophy, big coin pouch and Yggdrasil wood (WL6+) plus runestone
- Expand coin troll loot with world-level progression from FineWood and runestone up through IronScrap and Yggdrasil wood

## Testing
- `python Valheim_Help_Docs/List_Important_files.py both`


------
https://chatgpt.com/codex/tasks/task_e_688f4f44a7748331a61a95c929c93983