### PR TITLE
Add AvalancheDrake boss with EpicLoot rewards and distinct visuals

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -306,4 +306,13 @@ git commit -m "Add/Update: [specific mod] configuration files"
 
 ---
 
-**🎯 Remember**: This is a **comprehensive Valheim modding reference** focused on JewelHeim-RelicHeim. Every change impacts mod compatibility, user experience, and maintainability. **Progression balance is paramount**. 
+**🎯 Remember**: This is a **comprehensive Valheim modding reference** focused on JewelHeim-RelicHeim. Every change impacts mod compatibility, user experience, and maintainability. **Progression balance is paramount**.
+
+### Recent Updates
+- Added Dragon world spawner in Mountain biomes during SnowStorms with altitude gating.
+- Introduced AvalancheDrake boss scaling with a rock-summoning affix.
+- Configured AvalancheDrake loot drops with world-level tiers.
+- Expanded AvalancheDrake loot with DragonTears and EpicLoot enchanting materials.
+- Gave AvalancheDrake a unique Spirit infusion, enlarged size, and boss-level visuals.
+- Capped AvalancheDrake spawn level at five stars to respect star limits.
+- Scaled AvalancheDrake loot with world levels, adding XP orbs and lowering drop rates to encourage repeat fights.

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/CreatureConfig_Bosses.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/CreatureConfig_Bosses.yml
@@ -65,6 +65,24 @@ Dragon:
   affix power:
     Mending: 0.1
 
+AvalancheDrake:
+  size: 1.6
+  infusion:
+    Spirit: 1
+  health: 1.1
+  health per star: 0.1
+  attack speed: 1.2
+  movement speed: 1.2
+  damage: [1.2, 1.3, 1.4, 1.5, 1.6, 1.7]
+  affix:
+    Enraged: 40
+    Elementalist: 40
+    Summoner: 10
+    RockSummoner: 10
+    other: 0
+  affix power:
+    RockSummoner: 0.1
+
 GoblinKing:
   health: 1.1
   health per star: 0.05

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/drop_that.character_drop.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/drop_that.character_drop.cfg
@@ -314,3 +314,97 @@ SetAmountMax = 2
 SetChanceToDrop = 0.5
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
+
+[AvalancheDrake.1]
+PrefabName = FreezeGland
+EnableConfig = true
+SetAmountMin = 2
+SetAmountMax = 4
+SetChanceToDrop = 0.5
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 4
+ConditionWorldLevelMax = 5
+
+[AvalancheDrake.2]
+PrefabName = Crystal
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 2
+SetChanceToDrop = 0.3
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 6
+
+[AvalancheDrake.3]
+PrefabName = DragonTear
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.15
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 5
+
+[AvalancheDrake.4]
+PrefabName = DustEpic
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.2
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 6
+
+[AvalancheDrake.5]
+PrefabName = RunestoneEpic
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.15
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 6
+
+[AvalancheDrake.6]
+PrefabName = EssenceEpic
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.1
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 6
+
+[AvalancheDrake.7]
+PrefabName = mmo_orb5
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.2
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 5
+ConditionWorldLevelMax = 5
+
+[AvalancheDrake.8]
+PrefabName = mmo_orb6
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.15
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 6
+ConditionWorldLevelMax = 6
+
+[AvalancheDrake.9]
+PrefabName = mmo_orb7
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.1
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 7
+

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
@@ -88,3 +88,17 @@ SpawnInterval = 300
 SpawnChance = 30
 ConditionDistanceToCenterMin = 500
 
+[WorldSpawner.674]
+Name = AvalancheDrakeBoss
+PrefabName = Dragon
+Biomes = Mountain
+ConditionEnvironments = SnowStorm
+ConditionAltitudeMin = 100
+
+[WorldSpawner.674.CreatureLevelAndLootControl]
+SetName = AvalancheDrake
+SetBoss = true
+SetLevel = 5
+SetSize = 1.6
+SetInfusion = Spirit
+


### PR DESCRIPTION
## Summary
- Give AvalancheDrake its own world spawner with unique name, Spirit infusion, enlarged size, and boss-level stats
- Expand AvalancheDrake loot table with DragonTear, EpicLoot enchanting materials, and world-level scaled XP orbs
- Document boss visuals, EpicLoot drops, and world-level loot scaling in AGENTS memory
- Cap AvalancheDrake spawn level at five stars to respect star limit

## Testing
- `python List_Important_files.py both` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688f4f6056fc8331a49f08c403ab9bc8