### PR TITLE
Add Royal Lox event and configuration

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -307,3 +307,9 @@ git commit -m "Add/Update: [specific mod] configuration files"
 ---
 
 **🎯 Remember**: This is a **comprehensive Valheim modding reference** focused on JewelHeim-RelicHeim. Every change impacts mod compatibility, user experience, and maintainability. **Progression balance is paramount**. 
+## 🆕 Royal Lox Event
+- Added Harmony event hook (`RoyalLoxEvent.cs`) detecting 5-star Lox deaths and spawning an oversized replacement after a short delay.
+- Configured `spawn_that.world_spawners_advanced.cfg` with a `RoyalLoxEvent` trigger spawning scaled Lox in Plains grasslands.
+- Updated `CreatureConfig_Creatures.yml` to apply world-level scaling and amplified charge damage to Lox.
+- Expanded `drop_that.character_drop.cfg` loot table for Royal Lox with world-level gated drops and XP orbs.
+- Royal Lox gains magenta glow, boss status, and richer drops including scrap, linen, trophy, and pristine shard.

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/CreatureConfig_Creatures.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/CreatureConfig_Creatures.yml
@@ -244,6 +244,12 @@ Lox:
   count: 5
  effect power:
   Regenerating: 0.5
+ world level:
+  health: 1.2
+  damage: 1.2
+ attacks:
+  charge:
+   damage: 1.5
  tamed:
   damage: 0.6
   damage per star: 0.1

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/drop_that.character_drop.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/drop_that.character_drop.cfg
@@ -314,3 +314,115 @@ SetAmountMax = 2
 SetChanceToDrop = 0.5
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
+
+[RoyalLox.1]
+PrefabName = RoyalLoxPelt
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 1
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 5
+
+[RoyalLox.2]
+PrefabName = LoxMeat
+EnableConfig = true
+SetAmountMin = 6
+SetAmountMax = 10
+SetChanceToDrop = 1
+SetDropOnePerPlayer = false
+SetScaleByLevel = true
+ConditionWorldLevelMin = 5
+
+[RoyalLox.3]
+PrefabName = Coins
+EnableConfig = true
+SetAmountMin = 50
+SetAmountMax = 100
+SetChanceToDrop = 1
+SetDropOnePerPlayer = false
+SetScaleByLevel = true
+ConditionWorldLevelMin = 5
+
+[RoyalLox.4]
+PrefabName = EnchantmentShard_Balanced
+EnableConfig = true
+SetAmountMin = 2
+SetAmountMax = 4
+SetChanceToDrop = 0.5
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 5
+
+[RoyalLox.5]
+PrefabName = BlackMetalScrap
+EnableConfig = true
+SetAmountMin = 10
+SetAmountMax = 20
+SetChanceToDrop = 0.75
+SetDropOnePerPlayer = false
+SetScaleByLevel = true
+ConditionWorldLevelMin = 5
+
+[RoyalLox.6]
+PrefabName = LinenThread
+EnableConfig = true
+SetAmountMin = 10
+SetAmountMax = 20
+SetChanceToDrop = 0.75
+SetDropOnePerPlayer = false
+SetScaleByLevel = true
+ConditionWorldLevelMin = 5
+
+[RoyalLox.7]
+PrefabName = TrophyLox
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.5
+SetDropOnePerPlayer = true
+SetScaleByLevel = false
+ConditionWorldLevelMin = 5
+
+[RoyalLox.8]
+PrefabName = EnchantmentShard_Pristine
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.15
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 6
+
+[RoyalLox.9]
+PrefabName = mmo_orb5
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.2
+SetDropOnePerPlayer = true
+SetScaleByLevel = false
+ConditionWorldLevelMin = 5
+ConditionWorldLevelMax = 5
+
+[RoyalLox.10]
+PrefabName = mmo_orb6
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.15
+SetDropOnePerPlayer = true
+SetScaleByLevel = false
+ConditionWorldLevelMin = 6
+ConditionWorldLevelMax = 6
+
+[RoyalLox.11]
+PrefabName = mmo_orb7
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.1
+SetDropOnePerPlayer = true
+SetScaleByLevel = false
+ConditionWorldLevelMin = 7

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
@@ -88,3 +88,15 @@ SpawnInterval = 300
 SpawnChance = 30
 ConditionDistanceToCenterMin = 500
 
+
+[WorldSpawner.674]
+Name = Royal Lox
+PrefabName = Lox
+Biomes = Plains
+Enabled = true
+MaxSpawned = 1
+SpawnInterval = 600
+SpawnChance = 100
+ScaleMin = 1.6
+ScaleMax = 1.6
+ConditionRequiredGlobalKeys = RoyalLoxEvent

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/plugins/RoyalLoxEvent/RoyalLoxEvent.cs
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/plugins/RoyalLoxEvent/RoyalLoxEvent.cs
@@ -1,0 +1,77 @@
+using BepInEx;
+using HarmonyLib;
+using System.Collections;
+using UnityEngine;
+
+namespace RoyalLoxEventMod
+{
+    [BepInPlugin("com.valheimmods.royallox", "Royal Lox Event", "0.1.1")]
+    public class RoyalLoxEvent : BaseUnityPlugin
+    {
+        private Harmony _harmony;
+        internal static RoyalLoxEvent Instance { get; private set; }
+
+        private void Awake()
+        {
+            Instance = this;
+            _harmony = new Harmony("com.valheimmods.royallox");
+            _harmony.PatchAll();
+        }
+
+        private void OnDestroy()
+        {
+            _harmony?.UnpatchSelf();
+        }
+
+        public void ScheduleSpawn(Vector3 pos)
+        {
+            StartCoroutine(SpawnRoutine(pos));
+        }
+
+        private IEnumerator SpawnRoutine(Vector3 pos)
+        {
+            yield return new WaitForSeconds(5f);
+            var prefab = ZNetScene.instance?.GetPrefab("Lox");
+            if (prefab == null) yield break;
+            Vector3 spawnPos = pos + UnityEngine.Random.insideUnitSphere * 5f;
+            spawnPos.y = ZoneSystem.instance.GetGroundHeight(spawnPos);
+            var obj = Instantiate(prefab, spawnPos, Quaternion.identity);
+            obj.name = "RoyalLox";
+            obj.transform.localScale *= 1.6f;
+            var character = obj.GetComponent<Character>();
+            if (character != null)
+            {
+                character.m_level = 6;
+                character.m_name = "Royal Lox";
+                character.m_boss = true;
+            }
+            foreach (var renderer in obj.GetComponentsInChildren<Renderer>())
+            {
+                foreach (var mat in renderer.materials)
+                {
+                    mat.color = Color.magenta;
+                }
+            }
+            var light = obj.AddComponent<Light>();
+            light.color = Color.magenta;
+            light.range = 8f;
+            light.intensity = 2f;
+            ZoneSystem.instance.SetGlobalKey("RoyalLoxEvent");
+            yield return new WaitForSeconds(1f);
+            ZoneSystem.instance.RemoveGlobalKey("RoyalLoxEvent");
+        }
+    }
+
+    [HarmonyPatch(typeof(Character), nameof(Character.OnDeath))]
+    public static class LoxDeathPatch
+    {
+        public static void Postfix(Character __instance)
+        {
+            if (__instance != null && __instance.name == "Lox" && __instance.m_level >= 6)
+            {
+                RoyalLoxEvent.Instance?.ScheduleSpawn(__instance.transform.position);
+            }
+        }
+    }
+}
+

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/plugins/RoyalLoxEvent/manifest.json
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/plugins/RoyalLoxEvent/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "RoyalLoxEvent",
+  "version_number": "0.1.1",
+  "website_url": "https://example.com",
+  "description": "Spawns a glowing royal lox with boss loot when a 5-star lox dies.",
+  "dependencies": []
+}


### PR DESCRIPTION
## Summary
- Highlight Royal Lox spawn with boss flag, magenta glow, and light after five-star Lox deaths.
- Expand Royal Lox loot table with bigger coin purses, black metal scrap, linen thread, trophy, and pristine enchantment shard.
- Document Royal Lox visuals and loot upgrades.

## Testing
- `python Valheim_Help_Docs/List_Important_files.py both`


------
https://chatgpt.com/codex/tasks/task_e_688f4fc8ecc0833185eaa2d4038bd561