### PR TITLE
Add Ashlands golem spawn and drops

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -229,6 +229,7 @@ Valheim/profiles/Dogeheim_Player/BepInEx/config/
 - Provide independent loot rolls for group boss fights to incentivize co-op play.
 - Run rotating boss events with temporary loot modifiers or event-exclusive items.
 - Drop relic fragments that players combine into upgraded or legendary versions.
+- Added Ashlands Stone Golem spawning near lava in clear weather with high fire resistance, CLLC scaling, and world-level gated loot (Flametal/Obsidian/MagmaCore) plus rare XP orbs.
 
 ## 🛠️ Common Tasks & Commands
 

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/CreatureConfig_Bosses.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/CreatureConfig_Bosses.yml
@@ -365,3 +365,11 @@ BossBrutalis_TW:
     other: 0
   affix power:
     Mending: 0.1
+StoneGolem:
+  stars: [0, 15, 50, 25, 10]
+  damage: [1.15, 1.2, 1.25, 1.3, 1.35, 1.4]
+  damage taken:
+    Fire: 0.1
+  effect:
+    armored: 100
+    other: 0

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/drop_that.character_drop.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/drop_that.character_drop.cfg
@@ -314,3 +314,53 @@ SetAmountMax = 2
 SetChanceToDrop = 0.5
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
+[StoneGolem.1]
+PrefabName = FlametalNew
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 2
+SetChanceToDrop = 0.75
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 7
+
+[StoneGolem.2]
+PrefabName = Obsidian
+EnableConfig = true
+SetAmountMin = 2
+SetAmountMax = 5
+SetChanceToDrop = 0.75
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 7
+
+[StoneGolem.3]
+PrefabName = MagmaCore
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.05
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 8
+
+[StoneGolem.4]
+PrefabName = mmo_orb7
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.2
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 7
+ConditionWorldLevelMax = 7
+
+[StoneGolem.5]
+PrefabName = mmo_orb8
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.15
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 8

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
@@ -88,3 +88,13 @@ SpawnInterval = 300
 SpawnChance = 30
 ConditionDistanceToCenterMin = 500
 
+[WorldSpawner.674]
+Name = Ashlands Golem
+PrefabName = StoneGolem
+Biomes = AshLands
+Enabled = true
+MaxSpawned = 1
+SpawnInterval = 600
+SpawnChance = 25
+ConditionEnvironments = Clear
+ConditionNearbyLava = true


### PR DESCRIPTION
## Summary
- Gate Ashlands Stone Golem loot by world level with reduced drop rates
- Add level-specific XP orb rewards for repeat boss runs
- Record world-level loot scaling in project memory

## Testing
- `python Valheim_Help_Docs/List_Important_files.py both`


------
https://chatgpt.com/codex/tasks/task_e_688f5022df1c83319bc9748d94dee58c