### PR TITLE
Add Frost Dragon deep north boss configuration

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -304,6 +304,12 @@ git commit -m "Add/Update: [specific mod] configuration files"
 - **❌ Exclude**: `.dll`, `.exe`, `.png`, `.mp3`, large data files
 - **🎯 Priority**: Configuration files, documentation, metadata
 
+## 🆕 Recent Config Updates
+- Added Frost Dragon world spawn in DeepNorth with SnowStorm condition and altitude >= 100.
+- Introduced FrostDragon boss entry featuring frost breath and world-level scaling.
+- Created Dragon loot table dropping FrostScale, Silver, and a Legendary Weapon Schematic.
+- Gated Dragon loot by world level with rare Magic Orb drops and added WL7 spawn requirement.
+
 ---
 
 **🎯 Remember**: This is a **comprehensive Valheim modding reference** focused on JewelHeim-RelicHeim. Every change impacts mod compatibility, user experience, and maintainability. **Progression balance is paramount**. 

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/CreatureConfig_Bosses.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/CreatureConfig_Bosses.yml
@@ -365,3 +365,15 @@ BossBrutalis_TW:
     other: 0
   affix power:
     Mending: 0.1
+
+FrostDragon:
+  stars: [0, 15, 50, 25, 10]
+  health: 1
+  health per star: 0.02
+  damage: [1.2, 1.3, 1.4, 1.5, 1.6, 1.8]
+  damage taken:
+    Fire: 0.25
+    Bows: 0.5
+  infusion:
+    frost: 100
+    other: 0

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/drop_that.character_drop.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/drop_that.character_drop.cfg
@@ -314,3 +314,43 @@ SetAmountMax = 2
 SetChanceToDrop = 0.5
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
+
+[Dragon.1]
+PrefabName = FrostScale
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 3
+SetChanceToDrop = 1
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 7
+
+[Dragon.2]
+ PrefabName = Silver
+ EnableConfig = true
+ SetAmountMin = 10
+ SetAmountMax = 20
+ SetChanceToDrop = 0.3
+ SetDropOnePerPlayer = true
+ SetScaleByLevel = true
+ ConditionWorldLevelMin = 8
+
+[Dragon.3]
+ PrefabName = LegendaryWeaponSchematic
+ EnableConfig = true
+ SetAmountMin = 1
+ SetAmountMax = 1
+ SetChanceToDrop = 0.05
+ SetDropOnePerPlayer = true
+ SetScaleByLevel = true
+ ConditionWorldLevelMin = 9
+
+[Dragon.4]
+PrefabName = mmo_orb7
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 2
+SetChanceToDrop = 0.15
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 7

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
@@ -88,3 +88,13 @@ SpawnInterval = 300
 SpawnChance = 30
 ConditionDistanceToCenterMin = 500
 
+[WorldSpawner.674]
+Name = Frost Dragon
+PrefabName = Dragon
+Tint = blue
+Biomes = DeepNorth
+Enabled = true
+ConditionEnvironments = SnowStorm
+ConditionAltitudeMin = 100
+ConditionWorldLevelMin = 7
+


### PR DESCRIPTION
## Summary
- Spawn Frost Dragon in Deep North only during SnowStorms at high altitudes
- Configure FrostDragon boss with frost infusion and world-level scaling
- Gate Frost Dragon loot by world level and include rare Magic Orb drops

## Testing
- `python Valheim_Help_Docs/List_Important_files.py both`


------
https://chatgpt.com/codex/tasks/task_e_688f5026505c8331907e1b37e27e2002