### PR TITLE
Add Tempest Neck roaming boss configuration

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -230,6 +230,9 @@ Valheim/profiles/Dogeheim_Player/BepInEx/config/
 - Run rotating boss events with temporary loot modifiers or event-exclusive items.
 - Drop relic fragments that players combine into upgraded or legendary versions.
 
+## Roaming Bosses
+- **Tempest Neck**: Giant Neck that roams Meadows only during thunderstorms. Uses scaled Neck prefab (x3), lightning infusion, spawns away from player structures, and drops world-level gated coins, enchant scrolls, and thunderstones with low drop rates (F/B/A scrolls at 50%/35%/20%, thunderstones at 25%).
+
 ## 🛠️ Common Tasks & Commands
 
 ### **File Management**

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/CreatureConfig_Creatures.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/CreatureConfig_Creatures.yml
@@ -10,6 +10,17 @@ Neck:
 Boar:
   health: 3
   health per star: 1
+TempestNeck:
+  health: 200
+  health per star: 100
+  damage: 40
+  damage per star: 20
+  effect:
+    Quick: 10
+    Aggressive: 10
+    Regenerating: 5
+  infusion:
+    Lightning: 100
 #BlackForest
 Greydwarf:
   health: 1.25

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/drop_that.character_drop.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/drop_that.character_drop.cfg
@@ -314,3 +314,69 @@ SetAmountMax = 2
 SetChanceToDrop = 0.5
 SetDropOnePerPlayer = false
 SetScaleByLevel = false
+
+[TempestNeck.1]
+PrefabName = NeckTail
+EnableConfig = true
+SetAmountMin = 5
+SetAmountMax = 10
+SetChanceToDrop = 1
+SetDropOnePerPlayer = false
+SetScaleByLevel = true
+ConditionWorldLevelMin = 0
+ConditionWorldLevelMax = 2
+
+[TempestNeck.2]
+PrefabName = kg_EnchantSkillScroll_F
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.5
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 0
+ConditionWorldLevelMax = 2
+
+[TempestNeck.3]
+PrefabName = Coins
+EnableConfig = true
+SetAmountMin = 40
+SetAmountMax = 80
+SetChanceToDrop = 0.75
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 3
+ConditionWorldLevelMax = 5
+
+[TempestNeck.4]
+PrefabName = kg_EnchantSkillScroll_B
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.35
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 3
+ConditionWorldLevelMax = 5
+
+[TempestNeck.5]
+PrefabName = Thunderstone
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.25
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 6
+ConditionWorldLevelMax = 7
+
+[TempestNeck.6]
+PrefabName = kg_EnchantSkillScroll_A
+EnableConfig = true
+SetAmountMin = 1
+SetAmountMax = 1
+SetChanceToDrop = 0.2
+SetDropOnePerPlayer = true
+SetScaleByLevel = true
+ConditionWorldLevelMin = 6
+ConditionWorldLevelMax = 7

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
@@ -88,3 +88,14 @@ SpawnInterval = 300
 SpawnChance = 30
 ConditionDistanceToCenterMin = 500
 
+[WorldSpawner.TempestNeck]
+Name = Tempest Neck
+PrefabName = Neck
+Biomes = Meadows
+Enabled = true
+Scale = 3
+SpawnChance = 0.5
+ConditionEnvironments = Thunderstorm
+ConditionDistanceToPlayerStructuresMin = 500
+ConditionEvent = none
+


### PR DESCRIPTION
## Summary
- Introduce lightning-infused Tempest Neck roaming boss
- Balance Tempest Neck loot with world-level coins, enchant scrolls, and thunderstone drops
- Document Tempest Neck roaming boss under project memory

## Testing
- `python Valheim_Help_Docs/List_Important_files.py both`


------
https://chatgpt.com/codex/tasks/task_e_688f50cee970833182c18cad7e572300