### PR TITLE
feat: enhance bounty system with random rewards

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -179,6 +179,11 @@ Valheim/profiles/Dogeheim_Player/BepInEx/config/
 - **Solution**: Replaced chest loot with biome-specific sets and boosted legendary/mythic weights for late biomes
 - **Result**: Higher-tier chests now provide proportionally better materials
 
+### **Bounty Board Group Integration**
+- **Problem**: Group bounties required manual participant tracking and only split coin rewards
+- **Solution**: BountyBoard now uses the Groups API to auto-detect party members and divide coin and token rewards
+- **Result**: Cooperative bounties automatically share payouts among current group members
+
 ### **Treasure Chest Loot Rolls**
 - **Problem**: Some treasure chests could roll zero items.
 - **Solution**: Updated drop tables to remove zero-roll chance, ensuring a minimum of one item.
@@ -212,6 +217,7 @@ Valheim/profiles/Dogeheim_Player/BepInEx/config/
 - Managing multiple mod item lists without missing prefabs
 
 ### **Current Priorities**
+- Integrate bounty board plugin enabling random rewards, group hunts, and skill-gated bounties
 - Refine endgame loot pool using existing assets
 - Balance magic vs static loot drop rates
 - Ensure boss-locked BiS items feel worth the grind

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/EpicLoot/patches/RelicHeimPatches/AdventureData_Bounties_RelicHeim.json
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/EpicLoot/patches/RelicHeimPatches/AdventureData_Bounties_RelicHeim.json
@@ -1,318 +1,1501 @@
 {
-  "TargetFile": "adventuredata.json", 
+  "TargetFile": "adventuredata.json",
   "Author": "Majestic",
   "Priority": 900,
-  "RequireAll": true, 
+  "RequireAll": true,
   "Patches": [
     {
       "Path": "$.TreasureMap.RefreshInterval",
       "Action": "Overwrite",
       "Value": 2
     },
-	{
+    {
       "Path": "$.TreasureMap.BiomeInfo",
       "Action": "Overwrite",
-      "Value":  [
-      { "Biome": "Meadows",     "Cost": 100, "ForestTokens": 2,  "MinRadius": 0,		"MaxRadius": 1000 },
-      { "Biome": "BlackForest", "Cost": 200, "ForestTokens": 3,  "MinRadius": 300,		"MaxRadius": 2000 },
-      { "Biome": "Ocean",       "Cost": -1,  "ForestTokens": 0,  "MinRadius": 500,		"MaxRadius": 3000 },
-      { "Biome": "Swamp",       "Cost": 300, "ForestTokens": 4,  "MinRadius": 300,		"MaxRadius": 4000 },
-      { "Biome": "Mountain",    "Cost": 400, "ForestTokens": 5,  "MinRadius": 300,		"MaxRadius": 4000 },
-      { "Biome": "Plains",      "Cost": 500, "ForestTokens": 6,  "MinRadius": 2000,		"MaxRadius": 6000 },
-      { "Biome": "Mistlands",   "Cost": 600, "ForestTokens": 7,  "MinRadius": 4000,		"MaxRadius": 9000 },
-      { "Biome": "AshLands",   	"Cost": 700, "ForestTokens": 8,  "MinRadius": 8000, 	"MaxRadius": 10500 },
-      { "Biome": "DeepNorth",   "Cost": 800, "ForestTokens": 8,  "MinRadius": 8000, 	"MaxRadius": 10500 }
-	  ]
+      "Value": [
+        {
+          "Biome": "Meadows",
+          "Cost": 100,
+          "ForestTokens": 2,
+          "MinRadius": 0,
+          "MaxRadius": 1000
+        },
+        {
+          "Biome": "BlackForest",
+          "Cost": 200,
+          "ForestTokens": 3,
+          "MinRadius": 300,
+          "MaxRadius": 2000
+        },
+        {
+          "Biome": "Ocean",
+          "Cost": -1,
+          "ForestTokens": 0,
+          "MinRadius": 500,
+          "MaxRadius": 3000
+        },
+        {
+          "Biome": "Swamp",
+          "Cost": 300,
+          "ForestTokens": 4,
+          "MinRadius": 300,
+          "MaxRadius": 4000
+        },
+        {
+          "Biome": "Mountain",
+          "Cost": 400,
+          "ForestTokens": 5,
+          "MinRadius": 300,
+          "MaxRadius": 4000
+        },
+        {
+          "Biome": "Plains",
+          "Cost": 500,
+          "ForestTokens": 6,
+          "MinRadius": 2000,
+          "MaxRadius": 6000
+        },
+        {
+          "Biome": "Mistlands",
+          "Cost": 600,
+          "ForestTokens": 7,
+          "MinRadius": 4000,
+          "MaxRadius": 9000
+        },
+        {
+          "Biome": "AshLands",
+          "Cost": 700,
+          "ForestTokens": 8,
+          "MinRadius": 8000,
+          "MaxRadius": 10500
+        },
+        {
+          "Biome": "DeepNorth",
+          "Cost": 800,
+          "ForestTokens": 8,
+          "MinRadius": 8000,
+          "MaxRadius": 10500
+        }
+      ]
     },
-	{
+    {
       "Path": "$.TreasureMap.StartRadiusMin",
       "Action": "Overwrite",
       "Value": 0
     },
-	{
+    {
       "Path": "$.TreasureMap.StartRadiusMax",
       "Action": "Overwrite",
       "Value": 250
     },
-	{
+    {
       "Path": "$.TreasureMap.IncreaseRadiusCount",
       "Action": "Overwrite",
       "Value": 10
     },
-	{
+    {
       "Path": "$.TreasureMap.RadiusInterval",
       "Action": "Overwrite",
       "Value": 50
     },
-	{
+    {
       "Path": "$.TreasureMap.MinimapAreaRadius",
       "Action": "Overwrite",
       "Value": 45
     },
-	
-	
-	{
+    {
       "Path": "$.Bounties.RefreshInterval",
       "Action": "Overwrite",
       "Value": 1
     },
-	{
+    {
       "Path": "$.Bounties.IronMinLevel",
       "Action": "Overwrite",
       "Value": 3
     },
-	{
+    {
       "Path": "$.Bounties.IronMaxLevel",
       "Action": "Overwrite",
       "Value": 4
     },
-	{
+    {
       "Path": "$.Bounties.IronHealthMultiplier",
       "Action": "Overwrite",
       "Value": 2.5
     },
-	{
+    {
       "Path": "$.Bounties.GoldMinLevel",
       "Action": "Overwrite",
       "Value": 5
     },
-	{
+    {
       "Path": "$.Bounties.GoldMaxLevel",
       "Action": "Overwrite",
       "Value": 6
     },
-	{
+    {
       "Path": "$.Bounties.GoldHealthMultiplier",
       "Action": "Overwrite",
       "Value": 3.0
     },
-	{
+    {
       "Path": "$.Bounties.AddsMinLevel",
       "Action": "Overwrite",
       "Value": 3
     },
-	{
+    {
       "Path": "$.Bounties.AddsMaxLevel",
       "Action": "Overwrite",
       "Value": 3
     },
-	{
+    {
       "Path": "$.Bounties.AddsHealthMultiplier",
       "Action": "Overwrite",
       "Value": 2.0
     },
-	
-	{
-     "Path": "$.Bounties.Targets",
-     "Action": "Overwrite",
-     "Value": [
-	  { "Biome": "Meadows",     "TargetID": "Greyling",         	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 50  },
-      { "Biome": "Meadows",     "TargetID": "Greyling",             "RewardGold": 0, "RewardIron": 1, "RewardCoins": 75  },
-      { "Biome": "Meadows",     "TargetID": "Greyling",             "RewardGold": 0, "RewardIron": 1, "RewardCoins": 100 },
-      { "Biome": "Meadows",     "TargetID": "Boar",             	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 50  },
-      { "Biome": "Meadows",     "TargetID": "Boar",             	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 75	 },
-      { "Biome": "Meadows",     "TargetID": "Boar",             	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 100 },
-      { "Biome": "Meadows",     "TargetID": "Neck",             	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 50  },
-      { "Biome": "Meadows",     "TargetID": "Neck",             	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 75  },
-      { "Biome": "Meadows",     "TargetID": "Neck",             	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 100 },
-      { "Biome": "Meadows",     "TargetID": "Fox_TW",             	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 50  },
-      { "Biome": "Meadows",     "TargetID": "Fox_TW",             	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 75  },
-      { "Biome": "Meadows",     "TargetID": "Fox_TW",             	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 100 },
-      
-      { "Biome": "BlackForest", "TargetID": "Greydwarf",        	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 100   },
-      { "Biome": "BlackForest", "TargetID": "Greydwarf",        	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 150   },
-      { "Biome": "BlackForest", "TargetID": "Greydwarf",        	"RewardGold": 1, "RewardIron": 1, "RewardCoins": 200   },
-      { "Biome": "BlackForest", "TargetID": "Razorback_TW",        	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 150   },
-      { "Biome": "BlackForest", "TargetID": "Razorback_TW",        	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 200   },
-      { "Biome": "BlackForest", "TargetID": "Razorback_TW",        	"RewardGold": 1, "RewardIron": 1, "RewardCoins": 250   },
-      { "Biome": "BlackForest", "TargetID": "Ghost",  				"RewardGold": 0, "RewardIron": 0, "RewardCoins": 150   },
-      { "Biome": "BlackForest", "TargetID": "Ghost",  				"RewardGold": 0, "RewardIron": 1, "RewardCoins": 200   },
-      { "Biome": "BlackForest", "TargetID": "Ghost",  				"RewardGold": 1, "RewardIron": 1, "RewardCoins": 250   },
-      { "Biome": "BlackForest", "TargetID": "Skeleton",				"RewardGold": 0, "RewardIron": 0, "RewardCoins": 100   },
-      { "Biome": "BlackForest", "TargetID": "Skeleton", 			"RewardGold": 0, "RewardIron": 1, "RewardCoins": 150   },
-      { "Biome": "BlackForest", "TargetID": "Skeleton", 			"RewardGold": 1, "RewardIron": 1, "RewardCoins": 175   },
-      { "Biome": "BlackForest", "TargetID": "Greydwarf_Elite",  	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 200   },
-      { "Biome": "BlackForest", "TargetID": "Greydwarf_Elite",   	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 300   },
-      { "Biome": "BlackForest", "TargetID": "Greydwarf_Elite",   	"RewardGold": 1, "RewardIron": 1, "RewardCoins": 400   },	  
-      { "Biome": "BlackForest", "TargetID": "Greydwarf_Shaman", 	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 200   },
-      { "Biome": "BlackForest", "TargetID": "Greydwarf_Shaman", 	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 250   },
-      { "Biome": "BlackForest", "TargetID": "Greydwarf_Shaman", 	"RewardGold": 1, "RewardIron": 1, "RewardCoins": 300   },
-      { "Biome": "BlackForest", "TargetID": "BlackBear_TW", 		"RewardGold": 0, "RewardIron": 0, "RewardCoins": 200   },
-      { "Biome": "BlackForest", "TargetID": "BlackBear_TW", 		"RewardGold": 0, "RewardIron": 1, "RewardCoins": 250   },
-      { "Biome": "BlackForest", "TargetID": "BlackBear_TW", 		"RewardGold": 1, "RewardIron": 1, "RewardCoins": 300   },
-      { "Biome": "BlackForest", "TargetID": "GDAncientShaman_TW", 	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 250   },
-      { "Biome": "BlackForest", "TargetID": "GDAncientShaman_TW", 	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 300   },
-      { "Biome": "BlackForest", "TargetID": "GDAncientShaman_TW", 	"RewardGold": 1, "RewardIron": 1, "RewardCoins": 350   },
-      { "Biome": "BlackForest", "TargetID": "Troll",            	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 600   },
-      { "Biome": "BlackForest", "TargetID": "Troll",            	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 700   },
-      { "Biome": "BlackForest", "TargetID": "Troll",            	"RewardGold": 2, "RewardIron": 1, "RewardCoins": 800   },
-      
-      { "Biome": "Swamp",       "TargetID": "Blob",             	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 300   },
-      { "Biome": "Swamp",       "TargetID": "Blob",             	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 350   },
-      { "Biome": "Swamp",       "TargetID": "Blob",             	"RewardGold": 1, "RewardIron": 1, "RewardCoins": 400   },	  
-      { "Biome": "Swamp",       "TargetID": "Leech",            	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 300   },
-      { "Biome": "Swamp",       "TargetID": "Leech",            	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 350   },
-      { "Biome": "Swamp",       "TargetID": "Leech",            	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 400   },  
-      { "Biome": "Swamp",       "TargetID": "Draugr",           	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 300   },
-      { "Biome": "Swamp",       "TargetID": "Draugr",           	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 350   },
-      { "Biome": "Swamp",       "TargetID": "Draugr",           	"RewardGold": 1, "RewardIron": 1, "RewardCoins": 400   },  
-      { "Biome": "Swamp",       "TargetID": "RottingElk_TW",        "RewardGold": 0, "RewardIron": 0, "RewardCoins": 300   },
-      { "Biome": "Swamp",       "TargetID": "RottingElk_TW",        "RewardGold": 0, "RewardIron": 1, "RewardCoins": 350   },
-      { "Biome": "Swamp",       "TargetID": "RottingElk_TW",        "RewardGold": 1, "RewardIron": 1, "RewardCoins": 400   },
-      { "Biome": "Swamp",       "TargetID": "BlobElite",            "RewardGold": 0, "RewardIron": 0, "RewardCoins": 400   },
-      { "Biome": "Swamp",       "TargetID": "BlobElite",            "RewardGold": 0, "RewardIron": 1, "RewardCoins": 450   },
-      { "Biome": "Swamp",       "TargetID": "BlobElite",            "RewardGold": 1, "RewardIron": 1, "RewardCoins": 500   },  
-      { "Biome": "Swamp",       "TargetID": "Crawler_TW",     		"RewardGold": 0, "RewardIron": 0, "RewardCoins": 400   },
-      { "Biome": "Swamp",       "TargetID": "Crawler_TW",     		"RewardGold": 0, "RewardIron": 1, "RewardCoins": 500   },
-      { "Biome": "Swamp",       "TargetID": "Crawler_TW",     		"RewardGold": 1, "RewardIron": 1, "RewardCoins": 600   },  
-      { "Biome": "Swamp",       "TargetID": "Wraith",           	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 500   },
-      { "Biome": "Swamp",       "TargetID": "Wraith",           	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 600   },
-      { "Biome": "Swamp",       "TargetID": "Wraith",           	"RewardGold": 1, "RewardIron": 1, "RewardCoins": 700   },
-      { "Biome": "Swamp",       "TargetID": "HelWraith_TW",         "RewardGold": 0, "RewardIron": 0, "RewardCoins": 500   },
-      { "Biome": "Swamp",       "TargetID": "HelWraith_TW",			"RewardGold": 0, "RewardIron": 1, "RewardCoins": 600   },
-      { "Biome": "Swamp",       "TargetID": "HelWraith_TW",			"RewardGold": 1, "RewardIron": 1, "RewardCoins": 700   },	  
-      { "Biome": "Swamp",       "TargetID": "Draugr_Elite",     	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 500   },
-      { "Biome": "Swamp",       "TargetID": "Draugr_Elite",     	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 600   },
-      { "Biome": "Swamp",       "TargetID": "Draugr_Elite",     	"RewardGold": 1, "RewardIron": 1, "RewardCoins": 700   },	  
-      { "Biome": "Swamp",       "TargetID": "Abomination",      	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 800   },
-      { "Biome": "Swamp",       "TargetID": "Abomination",      	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 900  },
-      { "Biome": "Swamp",       "TargetID": "Abomination",     		"RewardGold": 2, "RewardIron": 1, "RewardCoins": 1000  },
-    
-      { "Biome": "Ocean",       "TargetID": "Serpent",				"RewardGold": 0, "RewardIron": 0, "RewardCoins": 500, "Adds": [ { "ID": "Shark_TW", "Count": 1 } ] },
-      { "Biome": "Ocean",       "TargetID": "Serpent",				"RewardGold": 0, "RewardIron": 1, "RewardCoins": 600, "Adds": [ { "ID": "Shark_TW", "Count": 2 } ] },
-      { "Biome": "Ocean",       "TargetID": "Serpent",				"RewardGold": 1, "RewardIron": 1, "RewardCoins": 700, "Adds": [ { "ID": "Shark_TW", "Count": 2 } ] },	
-      { "Biome": "Ocean",       "TargetID": "Shark_TW",				"RewardGold": 0, "RewardIron": 0, "RewardCoins": 500, "Adds": [ { "ID": "Serpent", "Count": 1 } ] },
-      { "Biome": "Ocean",       "TargetID": "Shark_TW",				"RewardGold": 0, "RewardIron": 1, "RewardCoins": 600, "Adds": [ { "ID": "Serpent", "Count": 2 } ] },
-      { "Biome": "Ocean",       "TargetID": "Shark_TW",				"RewardGold": 1, "RewardIron": 1, "RewardCoins": 700, "Adds": [ { "ID": "Serpent", "Count": 2 } ] },
-      
-      { "Biome": "Mountain",    "TargetID": "Wolf",             	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 500   },
-      { "Biome": "Mountain",    "TargetID": "Wolf",             	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 550   },
-      { "Biome": "Mountain",    "TargetID": "Wolf",             	"RewardGold": 1, "RewardIron": 1, "RewardCoins": 600   },  
-      { "Biome": "Mountain",    "TargetID": "Ulv",					"RewardGold": 0, "RewardIron": 0, "RewardCoins": 500   },
-      { "Biome": "Mountain",    "TargetID": "Ulv",             		"RewardGold": 0, "RewardIron": 1, "RewardCoins": 550   },
-      { "Biome": "Mountain",    "TargetID": "Ulv",					"RewardGold": 1, "RewardIron": 1, "RewardCoins": 600   },	  
-      { "Biome": "Mountain",    "TargetID": "Hatchling",        	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 500   },
-      { "Biome": "Mountain",    "TargetID": "Hatchling",			"RewardGold": 0, "RewardIron": 1, "RewardCoins": 550   },
-      { "Biome": "Mountain",    "TargetID": "Hatchling",			"RewardGold": 1, "RewardIron": 1, "RewardCoins": 600   },	  
-      { "Biome": "Mountain",    "TargetID": "GrizzlyBear_TW",       "RewardGold": 0, "RewardIron": 0, "RewardCoins": 600   },
-      { "Biome": "Mountain",    "TargetID": "GrizzlyBear_TW",       "RewardGold": 0, "RewardIron": 1, "RewardCoins": 700   },
-      { "Biome": "Mountain",    "TargetID": "GrizzlyBear_TW",       "RewardGold": 1, "RewardIron": 1, "RewardCoins": 800   },	  
-      { "Biome": "Mountain",    "TargetID": "Fenring",          	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 600   },
-      { "Biome": "Mountain",    "TargetID": "Fenring",				"RewardGold": 0, "RewardIron": 1, "RewardCoins": 700   },
-      { "Biome": "Mountain",    "TargetID": "Fenring",				"RewardGold": 1, "RewardIron": 1, "RewardCoins": 800   },	  
-	  { "Biome": "Mountain",    "TargetID": "Fenring_Cultist",  	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 600   },
-	  { "Biome": "Mountain",    "TargetID": "Fenring_Cultist",  	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 700  },
-	  { "Biome": "Mountain",    "TargetID": "Fenring_Cultist",  	"RewardGold": 2, "RewardIron": 1, "RewardCoins": 800  },	  
-      { "Biome": "Mountain",    "TargetID": "ObsidianGolem_TW",     "RewardGold": 0, "RewardIron": 0, "RewardCoins": 700   },
-      { "Biome": "Mountain",    "TargetID": "ObsidianGolem_TW",     "RewardGold": 0, "RewardIron": 1, "RewardCoins": 800   },
-      { "Biome": "Mountain",    "TargetID": "ObsidianGolem_TW",     "RewardGold": 2, "RewardIron": 1, "RewardCoins": 900   },	  
-      { "Biome": "Mountain",    "TargetID": "StoneGolem",        	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 1000  },
-      { "Biome": "Mountain",    "TargetID": "StoneGolem",        	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 1100  },
-      { "Biome": "Mountain",    "TargetID": "StoneGolem",        	"RewardGold": 2, "RewardIron": 2, "RewardCoins": 1200  },
-	
-      { "Biome": "Plains",      "TargetID": "Goblin",           	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 700  },
-      { "Biome": "Plains",      "TargetID": "Goblin",           	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 750  },
-      { "Biome": "Plains",      "TargetID": "Goblin",           	"RewardGold": 2, "RewardIron": 1, "RewardCoins": 800  },	  
-      { "Biome": "Plains",      "TargetID": "Deathsquito",      	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 700  },
-      { "Biome": "Plains",      "TargetID": "Deathsquito",      	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 750  },
-      { "Biome": "Plains",      "TargetID": "Deathsquito",      	"RewardGold": 2, "RewardIron": 1, "RewardCoins": 800  },	  
-	  { "Biome": "Plains",      "TargetID": "BlobTar",              "RewardGold": 0, "RewardIron": 0, "RewardCoins": 700  },
-	  { "Biome": "Plains",      "TargetID": "BlobTar",              "RewardGold": 0, "RewardIron": 1, "RewardCoins": 750  },
-	  { "Biome": "Plains",      "TargetID": "BlobTar",              "RewardGold": 2, "RewardIron": 1, "RewardCoins": 800  },	  
-      { "Biome": "Plains",      "TargetID": "GoblinShaman",     	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 700  },
-      { "Biome": "Plains",      "TargetID": "GoblinShaman",     	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 750  },
-      { "Biome": "Plains",      "TargetID": "GoblinShaman",     	"RewardGold": 2, "RewardIron": 1, "RewardCoins": 800  },	  
-	  { "Biome": "Plains",      "TargetID": "Prowler_TW",           "RewardGold": 0, "RewardIron": 0, "RewardCoins": 800  },
-	  { "Biome": "Plains",      "TargetID": "Prowler_TW",           "RewardGold": 0, "RewardIron": 1, "RewardCoins": 900  },
-	  { "Biome": "Plains",      "TargetID": "Prowler_TW",           "RewardGold": 2, "RewardIron": 1, "RewardCoins": 1000 },	  
-      { "Biome": "Plains",      "TargetID": "GoblinBrute",      	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 1200 },
-      { "Biome": "Plains",      "TargetID": "GoblinBrute",      	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 1300 },
-      { "Biome": "Plains",      "TargetID": "GoblinBrute",      	"RewardGold": 3, "RewardIron": 2, "RewardCoins": 1400 },	  
-	  { "Biome": "Plains",      "TargetID": "Lox",              	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 1200 },
-	  { "Biome": "Plains",      "TargetID": "Lox",              	"RewardGold": 0, "RewardIron": 1, "RewardCoins": 1300 },
-	  { "Biome": "Plains",      "TargetID": "Lox",              	"RewardGold": 3, "RewardIron": 2, "RewardCoins": 1400 },
-
-      { "Biome": "Mistlands",   "TargetID": "Seeker",           	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 800  },
-      { "Biome": "Mistlands",   "TargetID": "Seeker",           	"RewardGold": 0, "RewardIron": 2, "RewardCoins": 900  },
-      { "Biome": "Mistlands",   "TargetID": "Seeker",           	"RewardGold": 2, "RewardIron": 1, "RewardCoins": 1000 },	  
-      { "Biome": "Mistlands",   "TargetID": "Dverger", 				"RewardGold": 0, "RewardIron": 0, "RewardCoins": 800  },
-      { "Biome": "Mistlands",   "TargetID": "Dverger", 				"RewardGold": 0, "RewardIron": 2, "RewardCoins": 900  },
-      { "Biome": "Mistlands",   "TargetID": "Dverger", 				"RewardGold": 2, "RewardIron": 1, "RewardCoins": 1000 },	  
-      { "Biome": "Mistlands",   "TargetID": "DvergerMage", 			"RewardGold": 0, "RewardIron": 0, "RewardCoins": 800  },
-      { "Biome": "Mistlands",   "TargetID": "DvergerMage", 			"RewardGold": 0, "RewardIron": 2, "RewardCoins": 900  },
-      { "Biome": "Mistlands",   "TargetID": "DvergerMage", 			"RewardGold": 2, "RewardIron": 1, "RewardCoins": 1000 },  
-      { "Biome": "Mistlands",   "TargetID": "SeekerBrute",      	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 1400 },
-      { "Biome": "Mistlands",   "TargetID": "SeekerBrute",      	"RewardGold": 0, "RewardIron": 2, "RewardCoins": 1500 },
-      { "Biome": "Mistlands",   "TargetID": "SeekerBrute",      	"RewardGold": 3, "RewardIron": 2, "RewardCoins": 1600 },	  
-      { "Biome": "Mistlands",   "TargetID": "Gjall",            	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 1400 },
-      { "Biome": "Mistlands",   "TargetID": "Gjall",            	"RewardGold": 0, "RewardIron": 2, "RewardCoins": 1500 },
-      { "Biome": "Mistlands",   "TargetID": "Gjall",            	"RewardGold": 3, "RewardIron": 2, "RewardCoins": 1600 },
-
-      { "Biome": "AshLands",   "TargetID": "Charred_Archer",		"RewardGold": 0, "RewardIron": 0, "RewardCoins": 1200 },
-      { "Biome": "AshLands",   "TargetID": "Charred_Archer",		"RewardGold": 0, "RewardIron": 2, "RewardCoins": 1300 },
-      { "Biome": "AshLands",   "TargetID": "Charred_Archer",		"RewardGold": 3, "RewardIron": 2, "RewardCoins": 1400 },	  
-      { "Biome": "AshLands",   "TargetID": "Charred_Mage",			"RewardGold": 0, "RewardIron": 0, "RewardCoins": 1200 },
-      { "Biome": "AshLands",   "TargetID": "Charred_Mage",			"RewardGold": 0, "RewardIron": 2, "RewardCoins": 1300 },
-      { "Biome": "AshLands",   "TargetID": "Charred_Mage",			"RewardGold": 3, "RewardIron": 2, "RewardCoins": 1400 },  
-      { "Biome": "AshLands",   "TargetID": "BlobLava",				"RewardGold": 0, "RewardIron": 0, "RewardCoins": 1200 },
-      { "Biome": "AshLands",   "TargetID": "BlobLava",				"RewardGold": 0, "RewardIron": 2, "RewardCoins": 1300 },
-      { "Biome": "AshLands",   "TargetID": "BlobLava",				"RewardGold": 3, "RewardIron": 2, "RewardCoins": 1400 },	  
-      { "Biome": "AshLands",   "TargetID": "Charred_Melee",   		"RewardGold": 0, "RewardIron": 0, "RewardCoins": 1400 },
-      { "Biome": "AshLands",   "TargetID": "Charred_Melee",   		"RewardGold": 0, "RewardIron": 2, "RewardCoins": 1500 },
-      { "Biome": "AshLands",   "TargetID": "Charred_Melee",   		"RewardGold": 3, "RewardIron": 2, "RewardCoins": 1600 },	  
-      { "Biome": "AshLands",   "TargetID": "Asksvin",   			"RewardGold": 0, "RewardIron": 0, "RewardCoins": 1400 },
-      { "Biome": "AshLands",   "TargetID": "Asksvin",   			"RewardGold": 0, "RewardIron": 3, "RewardCoins": 1500 },
-      { "Biome": "AshLands",   "TargetID": "Asksvin",   			"RewardGold": 4, "RewardIron": 2, "RewardCoins": 1600 },	  
-      { "Biome": "AshLands",   "TargetID": "Morgen_NonSleeping",   	"RewardGold": 0, "RewardIron": 0, "RewardCoins": 1600 },
-      { "Biome": "AshLands",   "TargetID": "Morgen_NonSleeping",   	"RewardGold": 0, "RewardIron": 3, "RewardCoins": 1700 },
-      { "Biome": "AshLands",   "TargetID": "Morgen_NonSleeping",   	"RewardGold": 4, "RewardIron": 3, "RewardCoins": 1800 },	  
-      { "Biome": "AshLands",   "TargetID": "FallenValkyrie",   		"RewardGold": 0, "RewardIron": 0, "RewardCoins": 1600 },
-      { "Biome": "AshLands",   "TargetID": "FallenValkyrie",   		"RewardGold": 0, "RewardIron": 3, "RewardCoins": 1700 },
-      { "Biome": "AshLands",   "TargetID": "FallenValkyrie",   		"RewardGold": 4, "RewardIron": 3, "RewardCoins": 1800 },
-		
-	  { "Biome": "DeepNorth",		"TargetID": "SurtrImp_TW",			"RewardGold": 3, "RewardIron": 3, "RewardCoins": 1800 },
-	  { "Biome": "DeepNorth",		"TargetID": "SurtrDrake_TW",		"RewardGold": 3, "RewardIron": 3, "RewardCoins": 1800 },
-	  { "Biome": "DeepNorth",		"TargetID": "SurtrHound_TW",		"RewardGold": 3, "RewardIron": 3, "RewardCoins": 1800 },
-	  { "Biome": "DeepNorth",		"TargetID": "SurtrSeer_TW",			"RewardGold": 3, "RewardIron": 3, "RewardCoins": 1800 },
-	  { "Biome": "DeepNorth",		"TargetID": "SurtrWarbringer_TW",	"RewardGold": 3, "RewardIron": 3, "RewardCoins": 1800 },
-	  { "Biome": "DeepNorth",		"TargetID": "DaggerFang_TW",		"RewardGold": 3, "RewardIron": 3, "RewardCoins": 1800 },
-	  { "Biome": "DeepNorth",		"TargetID": "SurtrLegionnaire_TW",	"RewardGold": 5, "RewardIron": 5, "RewardCoins": 2200 },
-	  { "Biome": "DeepNorth",		"TargetID": "SurtrBrute_TW",		"RewardGold": 5, "RewardIron": 5, "RewardCoins": 2200 },
-		
-	  { "Biome": "DeepNorth",		"TargetID": "ArcticBear_TW",		"RewardGold": 3, "RewardIron": 3, "RewardCoins": 1800 },
-	  { "Biome": "DeepNorth",		"TargetID": "ArcticWolf_TW",		"RewardGold": 3, "RewardIron": 3, "RewardCoins": 1800 },
-	  { "Biome": "DeepNorth",		"TargetID": "StormCultist_TW",		"RewardGold": 3, "RewardIron": 3, "RewardCoins": 1800 },
-	  { "Biome": "DeepNorth",		"TargetID": "StormFenring_TW",		"RewardGold": 3, "RewardIron": 3, "RewardCoins": 1800 },
-	  { "Biome": "DeepNorth",		"TargetID": "JotunnBladefist_TW",	"RewardGold": 3, "RewardIron": 3, "RewardCoins": 1800 },
-	  { "Biome": "DeepNorth",		"TargetID": "JotunnShaman_TW",		"RewardGold": 3, "RewardIron": 3, "RewardCoins": 1800 },
-	  { "Biome": "DeepNorth",		"TargetID": "JotunnBrute_TW",		"RewardGold": 5, "RewardIron": 5, "RewardCoins": 2200 },
-	  { "Biome": "DeepNorth",		"TargetID": "JotunnJuggernaut_TW",	"RewardGold": 5, "RewardIron": 5, "RewardCoins": 2200 },
-	  { "Biome": "DeepNorth",		"TargetID": "ArcticGolem_TW",		"RewardGold": 5, "RewardIron": 5, "RewardCoins": 2200 },
-	  { "Biome": "DeepNorth",		"TargetID": "ArcticMammoth_TW",		"RewardGold": 5, "RewardIron": 5, "RewardCoins": 2200 }
-	 ]
-	},
-	{
-     "Path": "$.Bounties.Bosses",
-     "Action": "Overwrite",
-     "Value": [
-      {"Biome": "Meadows",      "BossPrefab": "Eikthyr",      "BossDefeatedKey": "defeated_eikthyr" },
-      {"Biome": "BlackForest",  "BossPrefab": "gd_king",      "BossDefeatedKey": "defeated_gdking" },
-      {"Biome": "Ocean",        "BossPrefab": "Bonemass",	  "BossDefeatedKey": "defeated_bonemass" }, 
-      {"Biome": "Swamp",        "BossPrefab": "Bonemass",     "BossDefeatedKey": "defeated_bonemass" },
-      {"Biome": "Mountain",     "BossPrefab": "Dragon",       "BossDefeatedKey": "defeated_dragon" },
-      {"Biome": "Plains",       "BossPrefab": "GoblinKing",   "BossDefeatedKey": "defeated_goblinking" },
-      {"Biome": "Mistlands",    "BossPrefab": "SeekerQueen",  "BossDefeatedKey": "defeated_queen" },
-      {"Biome": "AshLands",     "BossPrefab": "Fader",        "BossDefeatedKey": "defeated_fader" }
+    {
+      "Path": "$.Bounties.Targets",
+      "Action": "Overwrite",
+      "Value": [
+        {
+          "Biome": "Meadows",
+          "TargetID": "Greyling",
+          "GroupHunt": true,
+          "RewardOptions": [
+            {
+              "Weight": 50,
+              "RewardGold": 0,
+              "RewardIron": 0,
+              "RewardCoins": 50
+            },
+            {
+              "Weight": 30,
+              "RewardGold": 0,
+              "RewardIron": 1,
+              "RewardCoins": 75
+            },
+            {
+              "Weight": 20,
+              "RewardGold": 0,
+              "RewardIron": 1,
+              "RewardCoins": 100
+            }
+          ],
+          "RequiredSkill": {
+            "Name": "Swords",
+            "Level": 10
+          }
+        },
+        {
+          "Biome": "Meadows",
+          "TargetID": "Boar",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 50
+        },
+        {
+          "Biome": "Meadows",
+          "TargetID": "Boar",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 75
+        },
+        {
+          "Biome": "Meadows",
+          "TargetID": "Boar",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 100
+        },
+        {
+          "Biome": "Meadows",
+          "TargetID": "Neck",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 50
+        },
+        {
+          "Biome": "Meadows",
+          "TargetID": "Neck",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 75
+        },
+        {
+          "Biome": "Meadows",
+          "TargetID": "Neck",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 100
+        },
+        {
+          "Biome": "Meadows",
+          "TargetID": "Fox_TW",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 50
+        },
+        {
+          "Biome": "Meadows",
+          "TargetID": "Fox_TW",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 75
+        },
+        {
+          "Biome": "Meadows",
+          "TargetID": "Fox_TW",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 100
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "Greydwarf",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 100
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "Greydwarf",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 150
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "Greydwarf",
+          "RewardGold": 1,
+          "RewardIron": 1,
+          "RewardCoins": 200
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "Razorback_TW",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 150
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "Razorback_TW",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 200
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "Razorback_TW",
+          "RewardGold": 1,
+          "RewardIron": 1,
+          "RewardCoins": 250
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "Ghost",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 150
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "Ghost",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 200
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "Ghost",
+          "RewardGold": 1,
+          "RewardIron": 1,
+          "RewardCoins": 250
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "Skeleton",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 100
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "Skeleton",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 150
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "Skeleton",
+          "RewardGold": 1,
+          "RewardIron": 1,
+          "RewardCoins": 175
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "Greydwarf_Elite",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 200
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "Greydwarf_Elite",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 300
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "Greydwarf_Elite",
+          "RewardGold": 1,
+          "RewardIron": 1,
+          "RewardCoins": 400
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "Greydwarf_Shaman",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 200
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "Greydwarf_Shaman",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 250
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "Greydwarf_Shaman",
+          "RewardGold": 1,
+          "RewardIron": 1,
+          "RewardCoins": 300
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "BlackBear_TW",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 200
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "BlackBear_TW",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 250
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "BlackBear_TW",
+          "RewardGold": 1,
+          "RewardIron": 1,
+          "RewardCoins": 300
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "GDAncientShaman_TW",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 250
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "GDAncientShaman_TW",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 300
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "GDAncientShaman_TW",
+          "RewardGold": 1,
+          "RewardIron": 1,
+          "RewardCoins": 350
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "Troll",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 600
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "Troll",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 700
+        },
+        {
+          "Biome": "BlackForest",
+          "TargetID": "Troll",
+          "RewardGold": 2,
+          "RewardIron": 1,
+          "RewardCoins": 800,
+          "RequiredSkill": {
+            "Name": "Axes",
+            "Level": 40
+          },
+          "GroupHunt": true
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "Blob",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 300
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "Blob",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 350
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "Blob",
+          "RewardGold": 1,
+          "RewardIron": 1,
+          "RewardCoins": 400
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "Leech",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 300
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "Leech",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 350
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "Leech",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 400
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "Draugr",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 300
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "Draugr",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 350
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "Draugr",
+          "RewardGold": 1,
+          "RewardIron": 1,
+          "RewardCoins": 400
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "RottingElk_TW",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 300
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "RottingElk_TW",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 350
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "RottingElk_TW",
+          "RewardGold": 1,
+          "RewardIron": 1,
+          "RewardCoins": 400
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "BlobElite",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 400
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "BlobElite",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 450
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "BlobElite",
+          "RewardGold": 1,
+          "RewardIron": 1,
+          "RewardCoins": 500
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "Crawler_TW",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 400
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "Crawler_TW",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 500
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "Crawler_TW",
+          "RewardGold": 1,
+          "RewardIron": 1,
+          "RewardCoins": 600
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "Wraith",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 500
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "Wraith",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 600
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "Wraith",
+          "RewardGold": 1,
+          "RewardIron": 1,
+          "RewardCoins": 700
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "HelWraith_TW",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 500
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "HelWraith_TW",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 600
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "HelWraith_TW",
+          "RewardGold": 1,
+          "RewardIron": 1,
+          "RewardCoins": 700
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "Draugr_Elite",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 500
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "Draugr_Elite",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 600
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "Draugr_Elite",
+          "RewardGold": 1,
+          "RewardIron": 1,
+          "RewardCoins": 700
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "Abomination",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 800
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "Abomination",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 900
+        },
+        {
+          "Biome": "Swamp",
+          "TargetID": "Abomination",
+          "RewardGold": 2,
+          "RewardIron": 1,
+          "RewardCoins": 1000
+        },
+        {
+          "Biome": "Ocean",
+          "TargetID": "Serpent",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 500,
+          "Adds": [
+            {
+              "ID": "Shark_TW",
+              "Count": 1
+            }
+          ]
+        },
+        {
+          "Biome": "Ocean",
+          "TargetID": "Serpent",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 600,
+          "Adds": [
+            {
+              "ID": "Shark_TW",
+              "Count": 2
+            }
+          ]
+        },
+        {
+          "Biome": "Ocean",
+          "TargetID": "Serpent",
+          "RewardGold": 1,
+          "RewardIron": 1,
+          "RewardCoins": 700,
+          "Adds": [
+            {
+              "ID": "Shark_TW",
+              "Count": 2
+            }
+          ]
+        },
+        {
+          "Biome": "Ocean",
+          "TargetID": "Shark_TW",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 500,
+          "Adds": [
+            {
+              "ID": "Serpent",
+              "Count": 1
+            }
+          ]
+        },
+        {
+          "Biome": "Ocean",
+          "TargetID": "Shark_TW",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 600,
+          "Adds": [
+            {
+              "ID": "Serpent",
+              "Count": 2
+            }
+          ]
+        },
+        {
+          "Biome": "Ocean",
+          "TargetID": "Shark_TW",
+          "RewardGold": 1,
+          "RewardIron": 1,
+          "RewardCoins": 700,
+          "Adds": [
+            {
+              "ID": "Serpent",
+              "Count": 2
+            }
+          ]
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "Wolf",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 500
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "Wolf",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 550
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "Wolf",
+          "RewardGold": 1,
+          "RewardIron": 1,
+          "RewardCoins": 600
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "Ulv",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 500
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "Ulv",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 550
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "Ulv",
+          "RewardGold": 1,
+          "RewardIron": 1,
+          "RewardCoins": 600
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "Hatchling",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 500
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "Hatchling",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 550
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "Hatchling",
+          "RewardGold": 1,
+          "RewardIron": 1,
+          "RewardCoins": 600
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "GrizzlyBear_TW",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 600
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "GrizzlyBear_TW",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 700
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "GrizzlyBear_TW",
+          "RewardGold": 1,
+          "RewardIron": 1,
+          "RewardCoins": 800
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "Fenring",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 600
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "Fenring",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 700
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "Fenring",
+          "RewardGold": 1,
+          "RewardIron": 1,
+          "RewardCoins": 800
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "Fenring_Cultist",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 600
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "Fenring_Cultist",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 700
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "Fenring_Cultist",
+          "RewardGold": 2,
+          "RewardIron": 1,
+          "RewardCoins": 800
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "ObsidianGolem_TW",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 700
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "ObsidianGolem_TW",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 800
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "ObsidianGolem_TW",
+          "RewardGold": 2,
+          "RewardIron": 1,
+          "RewardCoins": 900
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "StoneGolem",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 1000
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "StoneGolem",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 1100
+        },
+        {
+          "Biome": "Mountain",
+          "TargetID": "StoneGolem",
+          "RewardGold": 2,
+          "RewardIron": 2,
+          "RewardCoins": 1200
+        },
+        {
+          "Biome": "Plains",
+          "TargetID": "Goblin",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 700
+        },
+        {
+          "Biome": "Plains",
+          "TargetID": "Goblin",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 750
+        },
+        {
+          "Biome": "Plains",
+          "TargetID": "Goblin",
+          "RewardGold": 2,
+          "RewardIron": 1,
+          "RewardCoins": 800
+        },
+        {
+          "Biome": "Plains",
+          "TargetID": "Deathsquito",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 700
+        },
+        {
+          "Biome": "Plains",
+          "TargetID": "Deathsquito",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 750
+        },
+        {
+          "Biome": "Plains",
+          "TargetID": "Deathsquito",
+          "RewardGold": 2,
+          "RewardIron": 1,
+          "RewardCoins": 800
+        },
+        {
+          "Biome": "Plains",
+          "TargetID": "BlobTar",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 700
+        },
+        {
+          "Biome": "Plains",
+          "TargetID": "BlobTar",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 750
+        },
+        {
+          "Biome": "Plains",
+          "TargetID": "BlobTar",
+          "RewardGold": 2,
+          "RewardIron": 1,
+          "RewardCoins": 800
+        },
+        {
+          "Biome": "Plains",
+          "TargetID": "GoblinShaman",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 700
+        },
+        {
+          "Biome": "Plains",
+          "TargetID": "GoblinShaman",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 750
+        },
+        {
+          "Biome": "Plains",
+          "TargetID": "GoblinShaman",
+          "RewardGold": 2,
+          "RewardIron": 1,
+          "RewardCoins": 800
+        },
+        {
+          "Biome": "Plains",
+          "TargetID": "Prowler_TW",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 800
+        },
+        {
+          "Biome": "Plains",
+          "TargetID": "Prowler_TW",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 900
+        },
+        {
+          "Biome": "Plains",
+          "TargetID": "Prowler_TW",
+          "RewardGold": 2,
+          "RewardIron": 1,
+          "RewardCoins": 1000
+        },
+        {
+          "Biome": "Plains",
+          "TargetID": "GoblinBrute",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 1200
+        },
+        {
+          "Biome": "Plains",
+          "TargetID": "GoblinBrute",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 1300
+        },
+        {
+          "Biome": "Plains",
+          "TargetID": "GoblinBrute",
+          "RewardGold": 3,
+          "RewardIron": 2,
+          "RewardCoins": 1400
+        },
+        {
+          "Biome": "Plains",
+          "TargetID": "Lox",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 1200
+        },
+        {
+          "Biome": "Plains",
+          "TargetID": "Lox",
+          "RewardGold": 0,
+          "RewardIron": 1,
+          "RewardCoins": 1300
+        },
+        {
+          "Biome": "Plains",
+          "TargetID": "Lox",
+          "RewardGold": 3,
+          "RewardIron": 2,
+          "RewardCoins": 1400
+        },
+        {
+          "Biome": "Mistlands",
+          "TargetID": "Seeker",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 800
+        },
+        {
+          "Biome": "Mistlands",
+          "TargetID": "Seeker",
+          "RewardGold": 0,
+          "RewardIron": 2,
+          "RewardCoins": 900
+        },
+        {
+          "Biome": "Mistlands",
+          "TargetID": "Seeker",
+          "RewardGold": 2,
+          "RewardIron": 1,
+          "RewardCoins": 1000
+        },
+        {
+          "Biome": "Mistlands",
+          "TargetID": "Dverger",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 800
+        },
+        {
+          "Biome": "Mistlands",
+          "TargetID": "Dverger",
+          "RewardGold": 0,
+          "RewardIron": 2,
+          "RewardCoins": 900
+        },
+        {
+          "Biome": "Mistlands",
+          "TargetID": "Dverger",
+          "RewardGold": 2,
+          "RewardIron": 1,
+          "RewardCoins": 1000
+        },
+        {
+          "Biome": "Mistlands",
+          "TargetID": "DvergerMage",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 800
+        },
+        {
+          "Biome": "Mistlands",
+          "TargetID": "DvergerMage",
+          "RewardGold": 0,
+          "RewardIron": 2,
+          "RewardCoins": 900
+        },
+        {
+          "Biome": "Mistlands",
+          "TargetID": "DvergerMage",
+          "RewardGold": 2,
+          "RewardIron": 1,
+          "RewardCoins": 1000
+        },
+        {
+          "Biome": "Mistlands",
+          "TargetID": "SeekerBrute",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 1400
+        },
+        {
+          "Biome": "Mistlands",
+          "TargetID": "SeekerBrute",
+          "RewardGold": 0,
+          "RewardIron": 2,
+          "RewardCoins": 1500
+        },
+        {
+          "Biome": "Mistlands",
+          "TargetID": "SeekerBrute",
+          "RewardGold": 3,
+          "RewardIron": 2,
+          "RewardCoins": 1600
+        },
+        {
+          "Biome": "Mistlands",
+          "TargetID": "Gjall",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 1400
+        },
+        {
+          "Biome": "Mistlands",
+          "TargetID": "Gjall",
+          "RewardGold": 0,
+          "RewardIron": 2,
+          "RewardCoins": 1500
+        },
+        {
+          "Biome": "Mistlands",
+          "TargetID": "Gjall",
+          "RewardGold": 3,
+          "RewardIron": 2,
+          "RewardCoins": 1600
+        },
+        {
+          "Biome": "AshLands",
+          "TargetID": "Charred_Archer",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 1200
+        },
+        {
+          "Biome": "AshLands",
+          "TargetID": "Charred_Archer",
+          "RewardGold": 0,
+          "RewardIron": 2,
+          "RewardCoins": 1300
+        },
+        {
+          "Biome": "AshLands",
+          "TargetID": "Charred_Archer",
+          "RewardGold": 3,
+          "RewardIron": 2,
+          "RewardCoins": 1400
+        },
+        {
+          "Biome": "AshLands",
+          "TargetID": "Charred_Mage",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 1200
+        },
+        {
+          "Biome": "AshLands",
+          "TargetID": "Charred_Mage",
+          "RewardGold": 0,
+          "RewardIron": 2,
+          "RewardCoins": 1300
+        },
+        {
+          "Biome": "AshLands",
+          "TargetID": "Charred_Mage",
+          "RewardGold": 3,
+          "RewardIron": 2,
+          "RewardCoins": 1400
+        },
+        {
+          "Biome": "AshLands",
+          "TargetID": "BlobLava",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 1200
+        },
+        {
+          "Biome": "AshLands",
+          "TargetID": "BlobLava",
+          "RewardGold": 0,
+          "RewardIron": 2,
+          "RewardCoins": 1300
+        },
+        {
+          "Biome": "AshLands",
+          "TargetID": "BlobLava",
+          "RewardGold": 3,
+          "RewardIron": 2,
+          "RewardCoins": 1400
+        },
+        {
+          "Biome": "AshLands",
+          "TargetID": "Charred_Melee",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 1400
+        },
+        {
+          "Biome": "AshLands",
+          "TargetID": "Charred_Melee",
+          "RewardGold": 0,
+          "RewardIron": 2,
+          "RewardCoins": 1500
+        },
+        {
+          "Biome": "AshLands",
+          "TargetID": "Charred_Melee",
+          "RewardGold": 3,
+          "RewardIron": 2,
+          "RewardCoins": 1600
+        },
+        {
+          "Biome": "AshLands",
+          "TargetID": "Asksvin",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 1400
+        },
+        {
+          "Biome": "AshLands",
+          "TargetID": "Asksvin",
+          "RewardGold": 0,
+          "RewardIron": 3,
+          "RewardCoins": 1500
+        },
+        {
+          "Biome": "AshLands",
+          "TargetID": "Asksvin",
+          "RewardGold": 4,
+          "RewardIron": 2,
+          "RewardCoins": 1600
+        },
+        {
+          "Biome": "AshLands",
+          "TargetID": "Morgen_NonSleeping",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 1600
+        },
+        {
+          "Biome": "AshLands",
+          "TargetID": "Morgen_NonSleeping",
+          "RewardGold": 0,
+          "RewardIron": 3,
+          "RewardCoins": 1700
+        },
+        {
+          "Biome": "AshLands",
+          "TargetID": "Morgen_NonSleeping",
+          "RewardGold": 4,
+          "RewardIron": 3,
+          "RewardCoins": 1800
+        },
+        {
+          "Biome": "AshLands",
+          "TargetID": "FallenValkyrie",
+          "RewardGold": 0,
+          "RewardIron": 0,
+          "RewardCoins": 1600
+        },
+        {
+          "Biome": "AshLands",
+          "TargetID": "FallenValkyrie",
+          "RewardGold": 0,
+          "RewardIron": 3,
+          "RewardCoins": 1700
+        },
+        {
+          "Biome": "AshLands",
+          "TargetID": "FallenValkyrie",
+          "RewardGold": 4,
+          "RewardIron": 3,
+          "RewardCoins": 1800
+        },
+        {
+          "Biome": "DeepNorth",
+          "TargetID": "SurtrImp_TW",
+          "RewardGold": 3,
+          "RewardIron": 3,
+          "RewardCoins": 1800
+        },
+        {
+          "Biome": "DeepNorth",
+          "TargetID": "SurtrDrake_TW",
+          "RewardGold": 3,
+          "RewardIron": 3,
+          "RewardCoins": 1800
+        },
+        {
+          "Biome": "DeepNorth",
+          "TargetID": "SurtrHound_TW",
+          "RewardGold": 3,
+          "RewardIron": 3,
+          "RewardCoins": 1800
+        },
+        {
+          "Biome": "DeepNorth",
+          "TargetID": "SurtrSeer_TW",
+          "RewardGold": 3,
+          "RewardIron": 3,
+          "RewardCoins": 1800
+        },
+        {
+          "Biome": "DeepNorth",
+          "TargetID": "SurtrWarbringer_TW",
+          "RewardGold": 3,
+          "RewardIron": 3,
+          "RewardCoins": 1800
+        },
+        {
+          "Biome": "DeepNorth",
+          "TargetID": "DaggerFang_TW",
+          "RewardGold": 3,
+          "RewardIron": 3,
+          "RewardCoins": 1800
+        },
+        {
+          "Biome": "DeepNorth",
+          "TargetID": "SurtrLegionnaire_TW",
+          "RewardGold": 5,
+          "RewardIron": 5,
+          "RewardCoins": 2200
+        },
+        {
+          "Biome": "DeepNorth",
+          "TargetID": "SurtrBrute_TW",
+          "RewardGold": 5,
+          "RewardIron": 5,
+          "RewardCoins": 2200
+        },
+        {
+          "Biome": "DeepNorth",
+          "TargetID": "ArcticBear_TW",
+          "RewardGold": 3,
+          "RewardIron": 3,
+          "RewardCoins": 1800
+        },
+        {
+          "Biome": "DeepNorth",
+          "TargetID": "ArcticWolf_TW",
+          "RewardGold": 3,
+          "RewardIron": 3,
+          "RewardCoins": 1800
+        },
+        {
+          "Biome": "DeepNorth",
+          "TargetID": "StormCultist_TW",
+          "RewardGold": 3,
+          "RewardIron": 3,
+          "RewardCoins": 1800
+        },
+        {
+          "Biome": "DeepNorth",
+          "TargetID": "StormFenring_TW",
+          "RewardGold": 3,
+          "RewardIron": 3,
+          "RewardCoins": 1800
+        },
+        {
+          "Biome": "DeepNorth",
+          "TargetID": "JotunnBladefist_TW",
+          "RewardGold": 3,
+          "RewardIron": 3,
+          "RewardCoins": 1800
+        },
+        {
+          "Biome": "DeepNorth",
+          "TargetID": "JotunnShaman_TW",
+          "RewardGold": 3,
+          "RewardIron": 3,
+          "RewardCoins": 1800
+        },
+        {
+          "Biome": "DeepNorth",
+          "TargetID": "JotunnBrute_TW",
+          "RewardGold": 5,
+          "RewardIron": 5,
+          "RewardCoins": 2200
+        },
+        {
+          "Biome": "DeepNorth",
+          "TargetID": "JotunnJuggernaut_TW",
+          "RewardGold": 5,
+          "RewardIron": 5,
+          "RewardCoins": 2200
+        },
+        {
+          "Biome": "DeepNorth",
+          "TargetID": "ArcticGolem_TW",
+          "RewardGold": 5,
+          "RewardIron": 5,
+          "RewardCoins": 2200
+        },
+        {
+          "Biome": "DeepNorth",
+          "TargetID": "ArcticMammoth_TW",
+          "RewardGold": 5,
+          "RewardIron": 5,
+          "RewardCoins": 2200
+        }
       ]
     },
-	{
-     "Path": "$.Bounties.Bosses",
-     "Action": "AppendAll",
-     "Value": [
-      {"Biome": "DeepNorth",	"BossPrefab": "BossSythrak_TW",			"BossDefeatedKey": "defeated_sythrak" },
-      {"Biome": "DeepNorth",	"BossPrefab": "BossBrutalis_TW",		"BossDefeatedKey": "defeated_brutalis" },
-      {"Biome": "DeepNorth",	"BossPrefab": "BossStormHerald_TW",		"BossDefeatedKey": "defeated_stormherald" },
-      {"Biome": "DeepNorth",	"BossPrefab": "BossGorr_TW",			"BossDefeatedKey": "defeated_gorr" }
+    {
+      "Path": "$.Bounties.Bosses",
+      "Action": "Overwrite",
+      "Value": [
+        {
+          "Biome": "Meadows",
+          "BossPrefab": "Eikthyr",
+          "BossDefeatedKey": "defeated_eikthyr"
+        },
+        {
+          "Biome": "BlackForest",
+          "BossPrefab": "gd_king",
+          "BossDefeatedKey": "defeated_gdking"
+        },
+        {
+          "Biome": "Ocean",
+          "BossPrefab": "Bonemass",
+          "BossDefeatedKey": "defeated_bonemass"
+        },
+        {
+          "Biome": "Swamp",
+          "BossPrefab": "Bonemass",
+          "BossDefeatedKey": "defeated_bonemass"
+        },
+        {
+          "Biome": "Mountain",
+          "BossPrefab": "Dragon",
+          "BossDefeatedKey": "defeated_dragon"
+        },
+        {
+          "Biome": "Plains",
+          "BossPrefab": "GoblinKing",
+          "BossDefeatedKey": "defeated_goblinking"
+        },
+        {
+          "Biome": "Mistlands",
+          "BossPrefab": "SeekerQueen",
+          "BossDefeatedKey": "defeated_queen"
+        },
+        {
+          "Biome": "AshLands",
+          "BossPrefab": "Fader",
+          "BossDefeatedKey": "defeated_fader"
+        }
+      ]
+    },
+    {
+      "Path": "$.Bounties.Bosses",
+      "Action": "AppendAll",
+      "Value": [
+        {
+          "Biome": "DeepNorth",
+          "BossPrefab": "BossSythrak_TW",
+          "BossDefeatedKey": "defeated_sythrak"
+        },
+        {
+          "Biome": "DeepNorth",
+          "BossPrefab": "BossBrutalis_TW",
+          "BossDefeatedKey": "defeated_brutalis"
+        },
+        {
+          "Biome": "DeepNorth",
+          "BossPrefab": "BossStormHerald_TW",
+          "BossDefeatedKey": "defeated_stormherald"
+        },
+        {
+          "Biome": "DeepNorth",
+          "BossPrefab": "BossGorr_TW",
+          "BossDefeatedKey": "defeated_gorr"
+        }
       ]
     }
   ]

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/shudnal.TradersExtended.MWL_BlackForestBlacksmith1_Trader.buy.json
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/shudnal.TradersExtended.MWL_BlackForestBlacksmith1_Trader.buy.json
@@ -146,5 +146,15 @@
     "stack": 1,
     "price": 20,
     "requiredGlobalKey": "defeated_gdking"
+  },
+  {
+    "prefab": "IronBountyToken",
+    "stack": 1,
+    "price": 100
+  },
+  {
+    "prefab": "GoldBountyToken",
+    "stack": 1,
+    "price": 300
   }
-] 
+]

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/shudnal.TradersExtended.MWL_MistlandsBlacksmith1_Trader.buy.json
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/shudnal.TradersExtended.MWL_MistlandsBlacksmith1_Trader.buy.json
@@ -253,5 +253,15 @@
     "prefab": "HelmetHat3",
     "stack": 1,
     "price": 200
+  },
+  {
+    "prefab": "IronBountyToken",
+    "stack": 1,
+    "price": 100
+  },
+  {
+    "prefab": "GoldBountyToken",
+    "stack": 1,
+    "price": 300
   }
-] 
+]

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/shudnal.TradersExtended.MWL_MountainsBlacksmith1_Trader.buy.json
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/shudnal.TradersExtended.MWL_MountainsBlacksmith1_Trader.buy.json
@@ -202,5 +202,15 @@
     "stack": 1,
     "price": 400,
     "requiredGlobalKey": "defeated_gdking"
+  },
+  {
+    "prefab": "IronBountyToken",
+    "stack": 1,
+    "price": 100
+  },
+  {
+    "prefab": "GoldBountyToken",
+    "stack": 1,
+    "price": 300
   }
-] 
+]

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/shudnal.TradersExtended.MWL_OceanTavern1_Trader.buy.json
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/shudnal.TradersExtended.MWL_OceanTavern1_Trader.buy.json
@@ -285,5 +285,15 @@
     "stack": 1,
     "price": 80,
     "requiredGlobalKey": "defeated_goblinking"
+  },
+  {
+    "prefab": "IronBountyToken",
+    "stack": 1,
+    "price": 100
+  },
+  {
+    "prefab": "GoldBountyToken",
+    "stack": 1,
+    "price": 300
   }
-] 
+]

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/shudnal.TradersExtended.MWL_PlainsCamp1_Trader.buy.json
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/shudnal.TradersExtended.MWL_PlainsCamp1_Trader.buy.json
@@ -309,5 +309,15 @@
     "prefab": "Hammer",
     "stack": 1,
     "price": 80
+  },
+  {
+    "prefab": "IronBountyToken",
+    "stack": 1,
+    "price": 100
+  },
+  {
+    "prefab": "GoldBountyToken",
+    "stack": 1,
+    "price": 300
   }
-] 
+]

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/shudnal.TradersExtended.MWL_PlainsTavern1_Trader.buy.json
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/shudnal.TradersExtended.MWL_PlainsTavern1_Trader.buy.json
@@ -292,5 +292,15 @@
     "stack": 1,
     "price": 20000,
     "requiredGlobalKey": "defeated_queen"
+  },
+  {
+    "prefab": "IronBountyToken",
+    "stack": 1,
+    "price": 100
+  },
+  {
+    "prefab": "GoldBountyToken",
+    "stack": 1,
+    "price": 300
   }
-] 
+]

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/plugins/Dogeheim-BountyBoard/BountyBoard.cs
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/plugins/Dogeheim-BountyBoard/BountyBoard.cs
@@ -1,0 +1,131 @@
+using BepInEx;
+using HarmonyLib;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Groups;
+
+namespace Dogeheim.BountyBoard
+{
+    [BepInPlugin("dogeheim.bountyboard", "Dogeheim Bounty Board", "0.1.0")]
+    [BepInDependency("org.bepinex.plugins.groups", BepInDependency.DependencyFlags.SoftDependency)]
+    public class BountyBoard : BaseUnityPlugin
+    {
+        private static readonly System.Random RNG = new();
+        private static readonly Dictionary<string, HashSet<long>> Participants = new();
+
+        private void Awake()
+        {
+            Harmony.CreateAndPatchAll(typeof(BountyBoard));
+        }
+
+        // Skill gating and group registration when a bounty is accepted
+        [HarmonyPrefix]
+        [HarmonyPatch("EpicLoot.BountiesManager", "AcceptBounty")]
+        private static bool CheckRequirements(object __instance, object bounty, Player player)
+        {
+            var data = Traverse.Create(bounty).Property("Data").GetValue<JObject>();
+
+            if (data.TryGetValue("RequiredSkill", out JToken reqSkill))
+            {
+                var name = reqSkill["Name"].Value<string>();
+                var level = reqSkill["Level"].Value<float>();
+                var type = (Skills.SkillType)Enum.Parse(typeof(Skills.SkillType), name, true);
+                if (player.GetSkills().GetSkillLevel(type) < level)
+                {
+                    player.Message(MessageHud.MessageType.Center, $"Requires {name} {level}");
+                    return false; // block acceptance
+                }
+            }
+
+            if (data.TryGetValue("GroupHunt", out JToken groupToken) && groupToken.Value<bool>())
+            {
+                string id = Traverse.Create(bounty).Property("ID").GetValue<string>();
+                if (!Participants.TryGetValue(id, out var set))
+                    Participants[id] = set = new HashSet<long>();
+
+                List<PlayerReference> members = API.GroupPlayers();
+                if (members.Count == 0)
+                {
+                    set.Add(player.GetPlayerID());
+                }
+                else
+                {
+                    foreach (PlayerReference m in members)
+                        set.Add(m.peerId);
+                }
+            }
+
+            return true; // allow
+        }
+
+        // Randomize rewards and split coin among participants
+        [HarmonyPostfix]
+        [HarmonyPatch("EpicLoot.BountiesManager", "CompleteBounty")]
+        private static void DistributeRewards(object __instance, object bounty)
+        {
+            var data = Traverse.Create(bounty).Property("Data").GetValue<JObject>();
+
+            if (data.TryGetValue("RewardOptions", out JToken rewardsToken))
+            {
+                var options = rewardsToken.ToObject<List<RewardOption>>();
+                int total = options.Sum(o => o.Weight);
+                int roll = RNG.Next(total);
+                int cumulative = 0;
+                RewardOption chosen = options[0];
+                foreach (var o in options)
+                {
+                    cumulative += o.Weight;
+                    if (roll < cumulative)
+                    {
+                        chosen = o;
+                        break;
+                    }
+                }
+
+                Traverse t = Traverse.Create(bounty);
+                t.Property("RewardGold").SetValue(chosen.RewardGold);
+                t.Property("RewardIron").SetValue(chosen.RewardIron);
+                t.Property("RewardCoins").SetValue(chosen.RewardCoins);
+            }
+
+            string id = Traverse.Create(bounty).Property("ID").GetValue<string>();
+            if (Participants.TryGetValue(id, out var set) && set.Count > 1)
+            {
+                Traverse t = Traverse.Create(bounty);
+                int coins = t.Property("RewardCoins").GetValue<int>();
+                int gold = t.Property("RewardGold").GetValue<int>();
+                int iron = t.Property("RewardIron").GetValue<int>();
+
+                int shareCoins = Mathf.FloorToInt(coins / (float)set.Count);
+                int shareGold = Mathf.FloorToInt(gold / (float)set.Count);
+                int shareIron = Mathf.FloorToInt(iron / (float)set.Count);
+
+                foreach (var pid in set)
+                {
+                    Player p = Player.GetPlayer(pid);
+                    if (p == null) continue;
+                    if (shareCoins > 0) p.GetInventory().AddItem("Coins", shareCoins);
+                    if (shareGold > 0) p.GetInventory().AddItem("GoldBountyToken", shareGold);
+                    if (shareIron > 0) p.GetInventory().AddItem("IronBountyToken", shareIron);
+                }
+
+                // prevent default rewards since we've distributed manually
+                t.Property("RewardCoins").SetValue(0);
+                t.Property("RewardGold").SetValue(0);
+                t.Property("RewardIron").SetValue(0);
+                Participants.Remove(id);
+            }
+        }
+
+        private class RewardOption
+        {
+            public int Weight { get; set; } = 1;
+            public int RewardGold { get; set; } = 0;
+            public int RewardIron { get; set; } = 0;
+            public int RewardCoins { get; set; } = 0;
+        }
+    }
+}

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/plugins/Dogeheim-BountyBoard/BountyBoard.csproj
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/plugins/Dogeheim-BountyBoard/BountyBoard.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <RootNamespace>Dogeheim.BountyBoard</RootNamespace>
+    <AssemblyName>Dogeheim-BountyBoard</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="BepInEx">
+      <HintPath>../../core/BepInEx.dll</HintPath>
+    </Reference>
+    <Reference Include="0Harmony">
+      <HintPath>../../core/0Harmony.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine">
+      <HintPath>../../core/UnityEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="EpicLoot">
+      <HintPath>../RandyKnapp-EpicLoot/EpicLoot.dll</HintPath>
+    </Reference>
+    <Reference Include="Jotunn">
+      <HintPath>../ValheimModding-Jotunn/Jotunn.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>../ValheimModding-JsonDotNET/Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="GroupsAPI">
+      <HintPath>../Smoothbrain-Groups/GroupsAPI.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- allow More World Trader configs to buy Iron and Gold bounty tokens from players
- add BountyBoard plugin to support random reward rolls, group bounty participation, and skill-gated tasks
- integrate Groups API so cooperative bounties automatically detect party members and split coin/token rewards
- extend bounty definitions with weighted reward options and skill requirements

## Testing
- `jq '.Patches[] | select(.Path=="$.Bounties.Targets").Value[] | select(.GroupHunt==true) | .TargetID' Valheim/profiles/Dogeheim_Player/BepInEx/config/EpicLoot/patches/RelicHeimPatches/AdventureData_Bounties_RelicHeim.json | head -n 20`
- `dotnet build Valheim/profiles/Dogeheim_Player/BepInEx/plugins/Dogeheim-BountyBoard/BountyBoard.csproj` *(fails: UnityEngine and BepInEx types not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f506278ec8331833e41bee2238c2a