### PR TITLE
Add Meadows treasure chest drop table

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/_RelicHeimFiles/Drop,Spawn_That/drop_that.drop_table.Chests.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/_RelicHeimFiles/Drop,Spawn_That/drop_that.drop_table.Chests.cfg
@@ -1,4 +1,33 @@
 ####################
+# Meadows
+####################
+
+[TreasureChest_meadows]
+SetDropChance=100
+SetDropOnlyOnce=True
+SetDropMin=2
+SetDropMax=4
+ConditionWorldLevelMin=1
+
+[TreasureChest_meadows.10]
+PrefabName=Flint
+SetTemplateWeight=1
+SetAmountMin=2
+SetAmountMax=4
+
+[TreasureChest_meadows.11]
+PrefabName=Resin
+SetTemplateWeight=1
+SetAmountMin=3
+SetAmountMax=6
+
+[TreasureChest_meadows.12]
+PrefabName=LeatherScraps
+SetTemplateWeight=0.5
+SetAmountMin=1
+SetAmountMax=3
+
+####################
 # BlackForest
 ####################
 


### PR DESCRIPTION
## Summary
- add Meadows chest configuration with early-biome loot

## Testing
- `pre-commit run --files Valheim/profiles/Dogeheim_Player/BepInEx/config/_RelicHeimFiles/Drop,Spawn_That/drop_that.drop_table.Chests.cfg` *(fails: `.pre-commit-config.yaml` is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_688f965f834c83318d3450c54fb3277c