### PR TITLE
Add missing loot tables for new chest prefabs

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/EpicLoot/patches/RelicHeimPatches/zLootables_TreasureLoot_RelicHeim.json
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/EpicLoot/patches/RelicHeimPatches/zLootables_TreasureLoot_RelicHeim.json
@@ -467,16 +467,81 @@
     },
 	
 	{
-	  "Path": "$.LootTables",
-	  "Action": "AppendAll",
-	  "Value": [
-	{
-	  "Object": "TreasureMapChest_DeepNorth",
-	  "Drops": [ [1, 0], [2, 0], [3, 70], [4, 30] ],
-	  "Loot": [
-		{ "Item": "HaldorChestAshDeep"}
-	  ]
-	}
+          "Path": "$.LootTables",
+          "Action": "AppendAll",
+          "Value": [
+        {
+          "Object": "TreasureMapChest_DeepNorth",
+          "WorldLevel": 7,
+          "Drops": [ [1, 0], [2, 0], [3, 70], [4, 30] ],
+          "Loot": [
+                { "Item": "HaldorChestAshDeep"}
+          ]
+        },
+        {
+          "Object": "TreasureChest_forestcrypt_hildir",
+          "WorldLevel": 2,
+          "Drops": [ [1, 50], [2, 35], [3, 15] ],
+          "Loot": [
+                { "Item": "HaldorChestBlackForest" }
+          ]
+        },
+        {
+          "Object": "TreasureChest_heath_hildir",
+          "WorldLevel": 5,
+          "Drops": [ [1, 50], [2, 35], [3, 15] ],
+          "Loot": [
+                { "Item": "HaldorChestPlains" }
+          ]
+        },
+        {
+          "Object": "TreasureChest_mountaincave_hildir",
+          "WorldLevel": 4,
+          "Drops": [ [1, 50], [2, 35], [3, 15] ],
+          "Loot": [
+                { "Item": "HaldorChestMountain" }
+          ]
+        },
+        {
+          "Object": "TreasureChest_plainsfortress_hildir",
+          "WorldLevel": 5,
+          "Drops": [ [1, 50], [2, 35], [3, 15] ],
+          "Loot": [
+                { "Item": "HaldorChestPlains" }
+          ]
+        },
+        {
+          "Object": "TreasureChest_DeepNorth_TW",
+          "WorldLevel": 7,
+          "Drops": [ [1, 50], [2, 35], [3, 15] ],
+          "Loot": [
+                { "Item": "HaldorChestAshDeep" }
+          ]
+        },
+        {
+          "Object": "TreasureChest_CaveDeepNorth_TW",
+          "WorldLevel": 7,
+          "Drops": [ [1, 50], [2, 35], [3, 15] ],
+          "Loot": [
+                { "Item": "HaldorChestAshDeep" }
+          ]
+        },
+        {
+          "Object": "TreasureChest_JotunnDungeon",
+          "WorldLevel": 7,
+          "Drops": [ [1, 50], [2, 35], [3, 15] ],
+          "Loot": [
+                { "Item": "HaldorChestAshDeep" }
+          ]
+        },
+        {
+          "Object": "TreasureChest_Muspelheim",
+          "WorldLevel": 7,
+          "Drops": [ [1, 50], [2, 35], [3, 15] ],
+          "Loot": [
+                { "Item": "HaldorChestAshDeep" }
+          ]
+        }
    ]
   }
  ]


### PR DESCRIPTION
## Summary
- enumerate Meadows chest prefabs from VNEI exports
- add EpicLoot loot table entries for Hildir and Deep North/Ashlands chest prefabs with appropriate item sets and world levels

## Testing
- `jq '.' Valheim/profiles/Dogeheim_Player/BepInEx/config/EpicLoot/patches/RelicHeimPatches/zLootables_TreasureLoot_RelicHeim.json`

------
https://chatgpt.com/codex/tasks/task_e_688f96601c34833191bef35743467f76