### PR TITLE
Patch Hildir heath chest with plains loot

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/EpicLoot/patches/RelicHeimPatches/zLootables_TreasureLoot_RelicHeim.json
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/EpicLoot/patches/RelicHeimPatches/zLootables_TreasureLoot_RelicHeim.json
@@ -296,21 +296,35 @@
         },
 
 	
-	{
+        {
       "Path": "$.LootTables[?(@.Object == 'TreasureChest_heath')].Drops",
       "Action": "Overwrite",
       "Value": [ [1, 50], [2, 35], [3, 15] ]
 
     },
-	{
+        {
           "Path": "$.LootTables[?(@.Object == 'TreasureChest_heath')].Loot",
           "Action": "Overwrite",
           "Value": [
                 { "Item": "HaldorChestPlains"}
           ]
         },
-	
-	{
+
+        {
+      "Path": "$.LootTables[?(@.Object == 'TreasureChest_heath_hildir')].Drops",
+      "Action": "Overwrite",
+      "Value": [ [1, 50], [2, 35], [3, 15] ]
+
+    },
+        {
+          "Path": "$.LootTables[?(@.Object == 'TreasureChest_heath_hildir')].Loot",
+          "Action": "Overwrite",
+          "Value": [
+                { "Item": "HaldorChestPlains"}
+          ]
+        },
+
+        {
       "Path": "$.LootTables[?(@.Object == 'TreasureChest_dvergrtown')].Drops",
       "Action": "Overwrite",
       "Value": [ [1, 50], [2, 35], [3, 15] ]


### PR DESCRIPTION
## Summary
- patch TreasureChest_heath_hildir drops and loot to use HaldorChestPlains distribution

## Testing
- `jq . Valheim/profiles/Dogeheim_Player/BepInEx/config/EpicLoot/patches/RelicHeimPatches/zLootables_TreasureLoot_RelicHeim.json | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_688f981c890083318ef7f89acd1088e5