### PR TITLE
Document boss trophy uses

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -373,3 +373,4 @@ git commit -m "Add/Update: [specific mod] configuration files"
 - Removed boss kill requirements from chest loot tables to eliminate gating on chest rewards.
 - Added Gameplay_Mod_Walkthrough.md summarizing gameplay mods and item sources.
 - Expanded Gameplay_Mod_Walkthrough.md with enchanting guidance, loot hunting strategies, and questing tips.
+- Documented post-story boss trophy uses (enchanting reagents, XP orbs, reset tokens).

--- a/Valheim_Help_Docs/Gameplay_Mod_Walkthrough.md
+++ b/Valheim_Help_Docs/Gameplay_Mod_Walkthrough.md
@@ -105,6 +105,12 @@ Mods like **Biome Lords Quest** and **Traders Extended** provide structured goal
 
 RelicHeim crafting uses these materials to forge end‑game gear and feast recipes for each biome.
 
+## Boss Trophy Uses
+Once the Forsaken altars are activated, extra boss trophies still provide value:
+- **Enchanting reagents** – Break trophies down at the Enchanting Table to produce Novus Reagent and other crafting materials.
+- **XP orbs and potions** – Wacky EpicMMO repurposes trophies, letting you grind bosses for ingredients used in XP orbs or experience potions.
+- **Reset tokens** – Spare trophies can become Reset Trophies, rare items the MMO system accepts in place of coins when refunding attribute points.
+
 ## Tips
 - Track world level progression and tackle biomes in order.
 - Carry repair materials; many mods increase durability loss.


### PR DESCRIPTION
## Summary
- outline post-story uses for boss trophies
- note enchanting reagent, XP orb/potion, and reset token applications

## Testing
- `python Valheim_Help_Docs/List_Important_files.py both`

------
https://chatgpt.com/codex/tasks/task_e_688fa6a97b1c8331a6fdc35648f0b066