### PR TITLE
Add loot fallback and validation for MWL chests

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.Meadows_Pack_1.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.Meadows_Pack_1.cfg
@@ -86,7 +86,7 @@ Use Custom Loot YAML file = On
 ## The name of the loot list to use from warpalicious.More_World_Locations_LootLists.yml file [Synced with Server]
 # Setting type: String
 # Default value: MeadowsLoot2
-Name of Loot List = MeadowsLoot2
+Name of Loot List = MeadowsLoot3
 
 [3 - MWL_Ruins3]
 
@@ -260,7 +260,7 @@ Use Custom Loot YAML file = On
 ## The name of the loot list to use from warpalicious.More_World_Locations_LootLists.yml file [Synced with Server]
 # Setting type: String
 # Default value: MeadowsLoot2
-Name of Loot List = MeadowsLoot2
+Name of Loot List = MeadowsLoot3
 
 [9 - MWL_RuinsChurch1]
 

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.More_World_Locations_LootLists.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.More_World_Locations_LootLists.yml
@@ -9,6 +9,10 @@ MeadowsLoot1:
   # Common locations - Basic weapons, armor, and survival items
   # Focus: Early-game equipment and essential materials for progression
   # Materials for enchanting economy
+  - item: Coins
+    stackMin: 5
+    stackMax: 20
+    weight: 1.0
   - item: DustMagic
     stackMin: 2
     stackMax: 5
@@ -113,6 +117,10 @@ MeadowsLoot2:
   # Uncommon locations - Enhanced weapons, armor, and better items
   # Focus: Mid-tier equipment and improved materials for progression
   # Materials for enchanting economy
+  - item: Coins
+    stackMin: 10
+    stackMax: 30
+    weight: 1.0
   - item: DustMagic
     stackMin: 3
     stackMax: 7
@@ -250,6 +258,10 @@ MeadowsLoot3:
   # Elite locations - Premium weapons, armor, and rare items
   # Focus: High-tier equipment and valuable materials for endgame progression
   # Materials for enchanting economy
+  - item: Coins
+    stackMin: 20
+    stackMax: 50
+    weight: 1.0
   - item: DustMagic
     stackMin: 4
     stackMax: 9

--- a/scripts/validate_mwl_loot.py
+++ b/scripts/validate_mwl_loot.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Validate More World Locations loot list references.
+
+Scans warpalicious location config files for locations that enable
+custom loot lists and verifies that the referenced list exists in the
+warpalicious.More_World_Locations_LootLists.yml file and contains at
+least one item.
+"""
+
+from __future__ import annotations
+import pathlib
+import re
+import sys
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+CONFIG_DIR = ROOT / "Valheim" / "profiles" / "Dogeheim_Player" / "BepInEx" / "config"
+LOOT_FILE = CONFIG_DIR / "warpalicious.More_World_Locations_LootLists.yml"
+
+try:
+    loot_data = yaml.safe_load(LOOT_FILE.read_text())
+except Exception as exc:  # pragma: no cover - printed for debugging
+    print(f"Failed to read loot lists: {exc}")
+    sys.exit(1)
+
+loot_lists = {k for k, v in loot_data.items() if isinstance(v, list) and v}
+
+missing: list[tuple[str, str]] = []
+for cfg_path in CONFIG_DIR.glob("warpalicious.*.cfg"):
+    lines = cfg_path.read_text().splitlines()
+    for i, line in enumerate(lines):
+        if line.strip().startswith("Use Custom Loot YAML file") and "On" in line:
+            for j in range(i + 1, min(i + 6, len(lines))):
+                m = re.search(r"Name of Loot List = (.+)", lines[j])
+                if m:
+                    name = m.group(1).strip()
+                    if name not in loot_lists:
+                        missing.append((str(cfg_path), name))
+                    break
+
+if missing:
+    print("Missing or empty loot lists found:")
+    for path, name in missing:
+        print(f"  {path}: {name}")
+    sys.exit(1)
+else:
+    print("All referenced loot lists exist and contain items.")


### PR DESCRIPTION
## Summary
- ensure MWL chest locations use valid loot list
- add coin fallback entries to early-meadows loot lists
- add validation script to catch missing or empty MWL loot lists

## Testing
- `scripts/validate_mwl_loot.py`

------
https://chatgpt.com/codex/tasks/task_e_688fd0d4bf688331a9c841874aca8e81