### PR TITLE
Ensure MWL locations use defined loot and creature tables

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.Blackforest_Pack_2.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.Blackforest_Pack_2.cfg
@@ -169,7 +169,7 @@ Spawn Quantity = 10
 # Setting type: Toggle
 # Default value: Off
 # Acceptable values: Off, On
-Use Custom Creature YAML file = Off
+Use Custom Creature YAML file = On
 
 ## The name of the creature list to use from warpalicious.More_World_Locations_CreatureLists.yml file [Synced with Server]
 # Setting type: String
@@ -180,7 +180,7 @@ Name of Creature List = BlackforestCreatures3
 # Setting type: Toggle
 # Default value: Off
 # Acceptable values: Off, On
-Use Custom Loot YAML file = Off
+Use Custom Loot YAML file = On
 
 ## The name of the loot list to use from warpalicious.More_World_Locations_LootLists.yml file [Synced with Server]
 # Setting type: String
@@ -198,7 +198,7 @@ Spawn Quantity = 15
 # Setting type: Toggle
 # Default value: Off
 # Acceptable values: Off, On
-Use Custom Creature YAML file = Off
+Use Custom Creature YAML file = On
 
 ## The name of the creature list to use from warpalicious.More_World_Locations_CreatureLists.yml file [Synced with Server]
 # Setting type: String
@@ -209,7 +209,7 @@ Name of Creature List = BlackforestCreatures2
 # Setting type: Toggle
 # Default value: Off
 # Acceptable values: Off, On
-Use Custom Loot YAML file = Off
+Use Custom Loot YAML file = On
 
 ## The name of the loot list to use from warpalicious.More_World_Locations_LootLists.yml file [Synced with Server]
 # Setting type: String
@@ -239,7 +239,7 @@ Spawn Quantity = 15
 # Setting type: Toggle
 # Default value: Off
 # Acceptable values: Off, On
-Use Custom Creature YAML file = Off
+Use Custom Creature YAML file = On
 
 ## The name of the creature list to use from warpalicious.More_World_Locations_CreatureLists.yml file [Synced with Server]
 # Setting type: String
@@ -250,7 +250,7 @@ Name of Creature List = BlackforestCreatures3
 # Setting type: Toggle
 # Default value: Off
 # Acceptable values: Off, On
-Use Custom Loot YAML file = Off
+Use Custom Loot YAML file = On
 
 ## The name of the loot list to use from warpalicious.More_World_Locations_LootLists.yml file [Synced with Server]
 # Setting type: String
@@ -280,7 +280,7 @@ Spawn Quantity = 15
 # Setting type: Toggle
 # Default value: Off
 # Acceptable values: Off, On
-Use Custom Creature YAML file = Off
+Use Custom Creature YAML file = On
 
 ## The name of the creature list to use from warpalicious.More_World_Locations_CreatureLists.yml file [Synced with Server]
 # Setting type: String
@@ -291,7 +291,7 @@ Name of Creature List = BlackforestCreatures1
 # Setting type: Toggle
 # Default value: Off
 # Acceptable values: Off, On
-Use Custom Loot YAML file = Off
+Use Custom Loot YAML file = On
 
 ## The name of the loot list to use from warpalicious.More_World_Locations_LootLists.yml file [Synced with Server]
 # Setting type: String
@@ -321,7 +321,7 @@ Spawn Quantity = 15
 # Setting type: Toggle
 # Default value: Off
 # Acceptable values: Off, On
-Use Custom Creature YAML file = Off
+Use Custom Creature YAML file = On
 
 ## The name of the creature list to use from warpalicious.More_World_Locations_CreatureLists.yml file [Synced with Server]
 # Setting type: String
@@ -332,7 +332,7 @@ Name of Creature List = BlackforestCreatures3
 # Setting type: Toggle
 # Default value: Off
 # Acceptable values: Off, On
-Use Custom Loot YAML file = Off
+Use Custom Loot YAML file = On
 
 ## The name of the loot list to use from warpalicious.More_World_Locations_LootLists.yml file [Synced with Server]
 # Setting type: String
@@ -362,7 +362,7 @@ Spawn Quantity = 15
 # Setting type: Toggle
 # Default value: Off
 # Acceptable values: Off, On
-Use Custom Creature YAML file = Off
+Use Custom Creature YAML file = On
 
 ## The name of the creature list to use from warpalicious.More_World_Locations_CreatureLists.yml file [Synced with Server]
 # Setting type: String
@@ -373,7 +373,7 @@ Name of Creature List = BlackforestCreatures3
 # Setting type: Toggle
 # Default value: Off
 # Acceptable values: Off, On
-Use Custom Loot YAML file = Off
+Use Custom Loot YAML file = On
 
 ## The name of the loot list to use from warpalicious.More_World_Locations_LootLists.yml file [Synced with Server]
 # Setting type: String

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.More_World_Locations_CreatureLists.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.More_World_Locations_CreatureLists.yml
@@ -114,6 +114,11 @@ MeadowsCreatures3:
   - Skeleton_Poison
   - Skeleton_NoArcher
 
+# Meadows Pack 2 Barns - peaceful farm animal spawns
+MeadowsCreatures5:
+  - Boar
+  - Boar
+
 # Black Forest Pack 1 - Enhanced Creature Variety
 # Thematic consistency with Black Forest biome identity
 BlackforestCreatures1:

--- a/scripts/validate_mwl_loot.py
+++ b/scripts/validate_mwl_loot.py
@@ -16,16 +16,20 @@ import yaml
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 CONFIG_DIR = ROOT / "Valheim" / "profiles" / "Dogeheim_Player" / "BepInEx" / "config"
 LOOT_FILE = CONFIG_DIR / "warpalicious.More_World_Locations_LootLists.yml"
+CREATURE_FILE = CONFIG_DIR / "warpalicious.More_World_Locations_CreatureLists.yml"
 
 try:
     loot_data = yaml.safe_load(LOOT_FILE.read_text())
+    creature_data = yaml.safe_load(CREATURE_FILE.read_text())
 except Exception as exc:  # pragma: no cover - printed for debugging
-    print(f"Failed to read loot lists: {exc}")
+    print(f"Failed to read config: {exc}")
     sys.exit(1)
 
 loot_lists = {k for k, v in loot_data.items() if isinstance(v, list) and v}
+creature_lists = {k for k, v in creature_data.items() if isinstance(v, list) and v}
 
-missing: list[tuple[str, str]] = []
+missing_loot: list[tuple[str, str]] = []
+missing_creature: list[tuple[str, str]] = []
 for cfg_path in CONFIG_DIR.glob("warpalicious.*.cfg"):
     lines = cfg_path.read_text().splitlines()
     for i, line in enumerate(lines):
@@ -35,13 +39,26 @@ for cfg_path in CONFIG_DIR.glob("warpalicious.*.cfg"):
                 if m:
                     name = m.group(1).strip()
                     if name not in loot_lists:
-                        missing.append((str(cfg_path), name))
+                        missing_loot.append((str(cfg_path), name))
+                    break
+        if line.strip().startswith("Use Custom Creature YAML file") and "On" in line:
+            for j in range(i + 1, min(i + 6, len(lines))):
+                m = re.search(r"Name of Creature List = (.+)", lines[j])
+                if m:
+                    name = m.group(1).strip()
+                    if name not in creature_lists:
+                        missing_creature.append((str(cfg_path), name))
                     break
 
-if missing:
-    print("Missing or empty loot lists found:")
-    for path, name in missing:
-        print(f"  {path}: {name}")
+if missing_loot or missing_creature:
+    if missing_loot:
+        print("Missing or empty loot lists found:")
+        for path, name in missing_loot:
+            print(f"  {path}: {name}")
+    if missing_creature:
+        print("Missing or empty creature lists found:")
+        for path, name in missing_creature:
+            print(f"  {path}: {name}")
     sys.exit(1)
 else:
-    print("All referenced loot lists exist and contain items.")
+    print("All referenced loot and creature lists exist and contain items.")


### PR DESCRIPTION
## Summary
- hook up missing Meadows barn creature list
- enable custom loot/creature tables for all Black Forest Pack 2 locations
- validate both loot and creature list references

## Testing
- `python3 scripts/validate_mwl_loot.py`


------
https://chatgpt.com/codex/tasks/task_e_688fd6476c108331bd2839cc23573cb7