### PR TITLE
Allow roaming bosses to scale with world level

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -381,3 +381,4 @@ git commit -m "Add/Update: [specific mod] configuration files"
 - Documented post-story boss trophy uses (enchanting reagents, XP orbs, reset tokens).
 - Refined Mushroom Monsters loot: replaced boss-exclusive fungi in Meadows and Black Forest with biome-appropriate resources and added drops for spore mobs.
 - Weighted mushroom monster drops toward biome-specific fungi for non-boss variants.
+- Enabled roaming bosses at all world levels and added world-level stat scaling for balanced difficulty progression.

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/CreatureConfig_Bosses.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/CreatureConfig_Bosses.yml
@@ -75,6 +75,9 @@ AvalancheDrake:
   attack speed: 1.2
   movement speed: 1.2
   damage: [1.2, 1.3, 1.4, 1.5, 1.6, 1.7]
+  world level:
+    health: 1.1
+    damage: 1.1
   affix:
     Enraged: 40
     Elementalist: 40
@@ -151,6 +154,9 @@ TempestSerpent:
   attack speed: 1.3
   movement speed: 1.2
   damage: [1.4, 1.5, 1.6, 1.7, 1.8, 2.0]
+  world level:
+    health: 1.1
+    damage: 1.1
   infusion:
     lightning: 100
   effect:
@@ -431,6 +437,9 @@ TempestNeck:
   attack speed: 1.1
   movement speed: 1.1
   damage: [1.1, 1.2, 1.3, 1.4, 1.5, 1.6]
+  world level:
+    health: 1.1
+    damage: 1.1
   affix:
     Enraged: 40
     Elementalist: 40
@@ -447,6 +456,9 @@ TollTroll:
   attack speed: 1.1
   movement speed: 1.1
   damage: [1.1, 1.2, 1.3, 1.4, 1.5, 1.6]
+  world level:
+    health: 1.1
+    damage: 1.1
   affix:
     Enraged: 40
     Elementalist: 40
@@ -463,6 +475,9 @@ LeechMatron:
   attack speed: 1.1
   movement speed: 1
   damage: [1.1, 1.2, 1.3, 1.4, 1.5, 1.6]
+  world level:
+    health: 1.1
+    damage: 1.1
   affix:
     Enraged: 40
     Elementalist: 40
@@ -479,6 +494,9 @@ RoyalLox:
   attack speed: 1.1
   movement speed: 1.1
   damage: [1.2, 1.3, 1.4, 1.5, 1.6, 1.7]
+  world level:
+    health: 1.1
+    damage: 1.1
   affix:
     Enraged: 40
     Elementalist: 40
@@ -495,6 +513,9 @@ WeaverQueen:
   attack speed: 1.1
   movement speed: 1.1
   damage: [1.2, 1.3, 1.4, 1.5, 1.6, 1.7]
+  world level:
+    health: 1.1
+    damage: 1.1
   affix:
     Enraged: 40
     Elementalist: 40
@@ -511,6 +532,9 @@ MagmaGolem:
   attack speed: 1
   movement speed: 1
   damage: [1.2, 1.3, 1.4, 1.5, 1.6, 1.7]
+  world level:
+    health: 1.1
+    damage: 1.1
   damage taken:
     Fire: 0.1
   affix:
@@ -529,6 +553,9 @@ FrostWyrm:
   attack speed: 1.1
   movement speed: 1.2
   damage: [1.2, 1.3, 1.4, 1.5, 1.6, 1.7]
+  world level:
+    health: 1.1
+    damage: 1.1
   infusion:
     Frost: 1
   affix:

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
@@ -112,9 +112,6 @@ SpawnInterval = 1200
 SpawnChance = 7.50
 TemplateId = CoinTroll
 
-[WorldSpawner.675.CreatureLevelAndLootControl]
-ConditionWorldLevelMin = 2
-
 [WorldSpawner.676]
 Name = Tempest Neck
 PrefabName = Neck
@@ -125,9 +122,6 @@ SpawnInterval = 1200
 SpawnChance = 37.50
 RequiredEnvironments = Thunderstorm
 TemplateId = TempestNeck
-
-[WorldSpawner.676.CreatureLevelAndLootControl]
-ConditionWorldLevelMax = 1
 
 [WorldSpawner.677]
 Name = Avalanche Drake
@@ -141,9 +135,6 @@ RequiredEnvironments = SnowStorm
 ConditionAltitudeMin = 100
 TemplateId = AvalancheDrake
 
-[WorldSpawner.677.CreatureLevelAndLootControl]
-ConditionWorldLevelMin = 4
-
 [WorldSpawner.678]
 Name = Tempest Serpent
 PrefabName = Serpent
@@ -153,12 +144,7 @@ MaxSpawned = 1
 SpawnInterval = 1800
 SpawnChance = 37.50
 RequiredEnvironments = ThunderStorm
-LevelMin = 6
-LevelMax = 6
 TemplateId = TempestSerpent
-
-[WorldSpawner.678.CreatureLevelAndLootControl]
-ConditionWorldLevelMin = 3
 
 [WorldSpawner.679]
 Name = Royal Lox
@@ -171,9 +157,6 @@ SpawnChance = 75.00
 RequiredGlobalKey = RoyalLoxEvent
 TemplateId = RoyalLox
 
-[WorldSpawner.679.CreatureLevelAndLootControl]
-ConditionWorldLevelMin = 5
-
 [WorldSpawner.680]
 Name = Ashlands Golem
 PrefabName = StoneGolem
@@ -185,9 +168,6 @@ SpawnChance = 18.75
 RequiredEnvironments = Clear
 TemplateId = MagmaGolem
 
-[WorldSpawner.680.CreatureLevelAndLootControl]
-ConditionWorldLevelMin = 7
-
 [WorldSpawner.681]
 Name = Seeker Queen
 PrefabName = SeekerQueen
@@ -197,9 +177,6 @@ MaxSpawned = 1
 SpawnInterval = 1200
 SpawnChance = 3.75
 TemplateId = SeekerQueen
-
-[WorldSpawner.681.CreatureLevelAndLootControl]
-ConditionWorldLevelMin = 6
 
 [WorldSpawner.682]
 Name = Leech Matron
@@ -215,9 +192,6 @@ SpawnDuringNight = true
 OceanDepthMin = 4
 TemplateId = LeechMatron
 
-[WorldSpawner.682.CreatureLevelAndLootControl]
-ConditionWorldLevelMin = 3
-
 [WorldSpawner.683]
 Name = Weaver Queen
 PrefabName = SeekerQueen
@@ -230,9 +204,6 @@ SpawnDuringDay = false
 SpawnDuringNight = true
 TemplateId = WeaverQueen
 
-[WorldSpawner.683.CreatureLevelAndLootControl]
-ConditionWorldLevelMin = 6
-
 [WorldSpawner.684]
 Name = Frost Wyrm
 PrefabName = Dragon
@@ -244,6 +215,3 @@ SpawnChance = 7.50
 RequiredEnvironments = SnowStorm
 ConditionAltitudeMin = 50
 TemplateId = FrostWyrm
-
-[WorldSpawner.684.CreatureLevelAndLootControl]
-ConditionWorldLevelMin = 7


### PR DESCRIPTION
## Summary
- Remove world-level spawn restrictions from roaming bosses
- Add world-level stat scaling to roaming boss configs
- Document roaming boss changes in AGENTS memory

## Testing
- `python Valheim_Help_Docs/List_Important_files.py both`
- `pip install pyyaml`
- `python scripts/validate_mwl_loot.py`


------
https://chatgpt.com/codex/tasks/task_e_688fd90af4888331b1dafa356231e696