### PR TITLE
Fix Epic Loot Hildir chest patch path

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -179,6 +179,11 @@ Valheim/profiles/Dogeheim_Player/BepInEx/config/
 - **Solution**: Renamed drop entry to `ShieldBronzeBuckler` and patched CoinTrollSpawn to register the custom troll during `ZNetScene.Awake`
 - **Result**: Prefabs now load correctly, eliminating configuration warnings
 
+### **Epic Loot Patch Errors**
+- **Problem**: Epic Loot reported missing paths for `TreasureChest_heath_hildir` in `zLootables_TreasureLoot_RelicHeim.json`
+- **Solution**: Removed overwrite entries so the chest is added only through `AppendAll`
+- **Result**: Patch applies cleanly without missing token errors
+
 ### **Tempest Serpent Boss Setup**
 - **Problem**: Tempest Serpent lacked distinct visuals and boss-worthy loot.
 - **Solution**: Capped level at 5-star limit, enlarged model with lightning infusion and armored effect, and expanded drop table with trophy, meat, coins, thunderstones, and legendary weapon rolls.

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/EpicLoot/patches/RelicHeimPatches/zLootables_TreasureLoot_RelicHeim.json
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/EpicLoot/patches/RelicHeimPatches/zLootables_TreasureLoot_RelicHeim.json
@@ -311,20 +311,6 @@
         },
 
         {
-      "Path": "$.LootTables[?(@.Object == 'TreasureChest_heath_hildir')].Drops",
-      "Action": "Overwrite",
-      "Value": [ [1, 50], [2, 35], [3, 15] ]
-
-    },
-        {
-          "Path": "$.LootTables[?(@.Object == 'TreasureChest_heath_hildir')].Loot",
-          "Action": "Overwrite",
-          "Value": [
-                { "Item": "HaldorChestPlains"}
-          ]
-        },
-
-        {
       "Path": "$.LootTables[?(@.Object == 'TreasureChest_dvergrtown')].Drops",
       "Action": "Overwrite",
       "Value": [ [1, 50], [2, 35], [3, 15] ]


### PR DESCRIPTION
## Summary
- remove invalid overwrite for TreasureChest_heath_hildir
- document fix in AGENTS memory

## Testing
- `python Valheim_Help_Docs/List_Important_files.py both`
- `jq . Valheim/profiles/Dogeheim_Player/BepInEx/config/EpicLoot/patches/RelicHeimPatches/zLootables_TreasureLoot_RelicHeim.json`


------
https://chatgpt.com/codex/tasks/task_e_688fecacf9688331b40b863d3113236e