### PR TITLE
Fix seed prefab names in More World Locations loot lists

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -179,6 +179,11 @@ Valheim/profiles/Dogeheim_Player/BepInEx/config/
 - **Solution**: Renamed drop entry to `ShieldBronzeBuckler` and patched CoinTrollSpawn to register the custom troll during `ZNetScene.Awake`
 - **Result**: Prefabs now load correctly, eliminating configuration warnings
 
+### **Seed Prefab Warnings**
+- **Problem**: More World Locations loot lists referenced `SeedCarrot`, `SeedTurnip`, and `SeedOnion` prefabs that don't exist.
+- **Solution**: Replaced entries with correct base-game IDs (`CarrotSeeds`, `TurnipSeeds`, `OnionSeeds`) in `warpalicious.More_World_Locations_LootLists.yml`.
+- **Result**: Seed items now spawn without warning logs.
+
 ### **Tempest Serpent Boss Setup**
 - **Problem**: Tempest Serpent lacked distinct visuals and boss-worthy loot.
 - **Solution**: Capped level at 5-star limit, enlarged model with lightning infusion and armored effect, and expanded drop table with trophy, meat, coins, thunderstones, and legendary weapon rolls.

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.More_World_Locations_LootLists.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.More_World_Locations_LootLists.yml
@@ -524,15 +524,15 @@ MeadowsPack2Loot2:
     stackMax: 4
     weight: 2.0
   # Farming-specific items
-  - item: SeedCarrot
+  - item: CarrotSeeds
     stackMin: 2
     stackMax: 6
     weight: 1.8
-  - item: SeedTurnip
+  - item: TurnipSeeds
     stackMin: 2
     stackMax: 6
     weight: 1.8
-  - item: SeedOnion
+  - item: OnionSeeds
     stackMin: 2
     stackMax: 6
     weight: 1.8


### PR DESCRIPTION
## Summary
- replace nonexistent SeedCarrot/Turnip/Onion prefabs with correct CarrotSeeds, TurnipSeeds, and OnionSeeds entries
- document fix in AGENTS memory

## Testing
- `python Valheim_Help_Docs/List_Important_files.py both`
- `python scripts/validate_mwl_loot.py Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.More_World_Locations_LootLists.yml`

------
https://chatgpt.com/codex/tasks/task_e_688fed2fce088331b6f5454b1e9c6b9b