### PR TITLE
Validate item prefabs in MWL loot lists

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -234,6 +234,11 @@ Valheim/profiles/Dogeheim_Player/BepInEx/config/
 - **Solution**: Replaced with `AxeSilver_TW` to match modded prefab.
 - **Result**: AxeSilver loot lists load without errors.
 
+### **Loot Prefab Validation**
+- **Problem**: Loot lists could reference item prefabs that don't exist.
+- **Solution**: Extended `validate_mwl_loot.py` to cross-check items against the VNEI registry and warn on unknown prefabs.
+- **Result**: Invalid loot entries are detected and reported.
+
 ## 🚨 Current Pain Points
 
 ### **Technical Challenges**


### PR DESCRIPTION
## Summary
- cross-check More World Locations loot list items against VNEI item registry
- warn about unknown item prefabs and exit with error
- document loot prefab validation in AGENTS memory

## Testing
- `python scripts/validate_mwl_loot.py` *(fails: Invalid item prefabs found: SoftTissue)*


------
https://chatgpt.com/codex/tasks/task_e_688ff51415f883319d44bc6a2c3e0b1d