### PR TITLE
Update: CLLC boss-kill progression

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -369,6 +369,7 @@ git commit -m "Add/Update: [specific mod] configuration files"
 - Added BlackForest and TrollCave chest tables with seeds, amber, coins, and troll hide.
 - Restored Burial-chamber chest loot by adding missing `[TreasureChest_forestcrypt]` block and setting SurtlingCore weight to `1`.
 - Added Drop That chest entries for Hildir quest and Deep North/Muspelheim chests to restore loot generation.
+- Switched CLLC creature scaling to use BossesKilled and set world level day thresholds to 9999 to disable time-based progression.
 
 ---
 

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.creaturelevelcontrol.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.creaturelevelcontrol.cfg
@@ -98,7 +98,7 @@ Difficulty = Very_hard
 # Setting type: DifficultySecondFactor
 # Default value: BossesKilled
 # Acceptable values: None, Age_of_world, Distance, BossesKilled
-Second factor = Distance
+Second factor = BossesKilled
 
 ## Display circles on the map for distance from spawn option.
 # Setting type: Toggle
@@ -341,37 +341,37 @@ Damage gained per star for bosses (percentage) = 20
 ## Days needed to pass before your world gets to world level 1.
 # Setting type: Int32
 # Default value: 10
-World level 1 start (days) = 10
+World level 1 start (days) = 9999
 
 ## Days needed to pass before your world gets to world level 2.
 # Setting type: Int32
 # Default value: 25
-World level 2 start (days) = 25
+World level 2 start (days) = 9999
 
 ## Days needed to pass before your world gets to world level 3.
 # Setting type: Int32
 # Default value: 50
-World level 3 start (days) = 50
+World level 3 start (days) = 9999
 
 ## Days needed to pass before your world gets to world level 4.
 # Setting type: Int32
 # Default value: 100
-World level 4 start (days) = 100
+World level 4 start (days) = 9999
 
 ## Days needed to pass before your world gets to world level 5.
 # Setting type: Int32
 # Default value: 250
-World level 5 start (days) = 250
+World level 5 start (days) = 9999
 
 ## Days needed to pass before your world gets to world level 6.
 # Setting type: Int32
 # Default value: 400
-World level 6 start (days) = 500
+World level 6 start (days) = 9999
 
 ## Days needed to pass before your world gets to world level 7.
 # Setting type: Int32
 # Default value: 600
-World level 7 start (days) = 600
+World level 7 start (days) = 9999
 
 [5 - Custom level chances]
 


### PR DESCRIPTION
## Summary
- shift CLLC creature scaling to use bosses killed
- disable day-based world level progression

## Testing
- `python List_Important_files.py both` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6893c5198c408331838fecf39a2b281d