### PR TITLE
Enable biome enforcement and slow farming XP

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -34,7 +34,7 @@ Build a **RuneScape + Solo Leveling** inspired Valheim experience with RPG/MMO p
 - **Blood Magic**: 33% XP sharing between shield caster and attacker
 
 ### **Vanilla Skill Experience Factors**
-- **Farming**: 1.25x (boosted - most rewarding)
+- **Farming**: 0.6x (reduced for slower progression)
 - **Cooking**: 0.6x (reduced)
 - **Ranching**: 0.6x (reduced)
 - **Exploration**: 0.6x (reduced)
@@ -361,6 +361,7 @@ git commit -m "Add/Update: [specific mod] configuration files"
 - **🎯 Priority**: Configuration files, documentation, metadata
 
 ## 🆕 Recent Config Updates
+- Enabled biome enforcement in PlantEverything and reduced Farming XP gain factor to 0.6.
 - Added Frost Dragon world spawn in DeepNorth with SnowStorm condition and altitude >= 100.
 - Introduced FrostDragon boss entry featuring frost breath and world-level scaling.
 - Created Dragon loot table dropping FrostScale, Silver, and a Legendary Weapon Schematic.

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/advize.PlantEverything.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/advize.PlantEverything.cfg
@@ -267,7 +267,7 @@ PlaceAnywhere = false
 ## Restrict modded plantables (pickables and saplings) to being placed in their respective biome.
 # Setting type: Boolean
 # Default value: false
-EnforceBiomes = false
+EnforceBiomes = true
 
 ## Restrict vanilla plantables (crops and saplings) to being placed in their respective biome.
 # Setting type: Boolean

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.farming.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.farming.cfg
@@ -65,7 +65,7 @@ Random Rotation = Off
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill Experience Gain Factor = 1.25
+Skill Experience Gain Factor = 0.6
 
 ## How much experience to lose in the farming skill on death.
 # Setting type: Int32

--- a/Valheim_Help_Docs/Summaries/Gameplay_Mod_Walkthrough.md
+++ b/Valheim_Help_Docs/Summaries/Gameplay_Mod_Walkthrough.md
@@ -56,6 +56,25 @@ Each skill module expands a survival activity.  Enable/disable in BepInEx config
 - **PassivePowers** – Unlock passive abilities as you level vanilla skills.
 - **TargetPortal & Sailing/SailingSpeed** – Upgrade portal usage and ship handling.
 
+## Farming Guide
+Farming underpins late‑game self‑sufficiency and requires deliberate leveling to unlock its strongest perks.
+
+### Leveling Path
+- **Levels 1‑20:** Plant carrots and turnips in their native biomes to learn basics. Sleep between plantings to accelerate growth.
+- **Levels 21‑40:** Expand plots and replant immediately after harvest. Multi‑planting/harvesting increases every 10 levels.
+- **Levels 41‑70:** Dedicated farming sessions become essential. Larger harvest radii and stamina reductions make mass farming viable.
+- **Level 80+:** Biome restrictions lift (via PlantEverything `EnforceBiomes`), letting you consolidate crops in one safe hub.
+
+### Efficiency Tips
+- Keep fields near portals and use fenced grids to maximize space.
+- Sleep or pass time between cycles to advance growth timers.
+- Replant immediately for continuous XP; every plant/harvest action grants experience.
+
+### Power Spikes
+- **L40:** Harvest/plant four crops at a time with ~40% less stamina.
+- **L70:** Growth speed hits ~2.4× and yields ~1.7×, making farming a major resource source.
+- **L100:** Zero stamina cost and wide harvest radius enable massive automated fields.
+
 ## Content & World Mods
 - **Therzie Warfare, Armory and Monstrum** – Large collections of weapons, armours and enemies.  Craft items at new stations such as the **Warfare Forge**.
 - **Therzie Wizardry** and **Magic Revamp** – Adds staffs, spells and Eitr‑based combat.  Equip wands and cast from a dedicated hotbar.


### PR DESCRIPTION
## Summary
- Enforce PlantEverything biome checks so crops honor farming level restrictions
- Slow farming skill progression by setting XP gain factor to 0.6
- Add a detailed farming guide to the gameplay walkthrough and document config changes in AGENTS

## Testing
- `python List_Important_files.py both` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893d2cdb41c83318be28cd07e3063af