### PR TITLE
Expand juvenile monster spawns and adjust adult rates

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -403,3 +403,5 @@ git commit -m "Add/Update: [specific mod] configuration files"
 - Weighted mushroom monster drops toward biome-specific fungi for non-boss variants.
 - Introduced Prefab Icon Loader plugin that derives icon filenames, loads textures with placeholder fallback, and stores a Texture2D reference for each prefab.
 - Added prefab name parser script to extract internal and localized names from VNEI exports.
+- Added juvenile world spawns for Boar piggies, Wolf cubs, and Lox calves with reduced adult spawn frequencies to limit overhead.
+- Added juvenile world spawns for Fox cubs, Razorback piglets, Black Bear cubs, Grizzly cubs, and Prowler cubs with matched world-level gating and further reduced adult spawn frequencies.

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.simple.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.simple.cfg
@@ -136,7 +136,7 @@ GroupSizeMinMultiplier = 1
 GroupSizeMaxMultiplier = 1
 # Change how often the game will try to spawn in new creatures.
 # Higher means more often. 2 is twice as often, 0.5 is double the time between spawn checks.
-SpawnFrequencyMultiplier = 0.95
+SpawnFrequencyMultiplier = 0.90
 
 [NECK]
 # Prefab name of entity to modify.
@@ -421,7 +421,7 @@ GroupSizeMinMultiplier = 1
 GroupSizeMaxMultiplier = 1
 # Change how often the game will try to spawn in new creatures.
 # Higher means more often. 2 is twice as often, 0.5 is double the time between spawn checks.
-SpawnFrequencyMultiplier = 0.95
+SpawnFrequencyMultiplier = 0.90
 
 [HATCHLING]
 # Prefab name of entity to modify.
@@ -496,7 +496,7 @@ GroupSizeMinMultiplier = 1
 GroupSizeMaxMultiplier = 1
 # Change how often the game will try to spawn in new creatures.
 # Higher means more often. 2 is twice as often, 0.5 is double the time between spawn checks.
-SpawnFrequencyMultiplier = 0.95
+SpawnFrequencyMultiplier = 0.90
 
 [GOBLIN]
 # Prefab name of entity to modify.
@@ -595,7 +595,7 @@ Enable = true
 SpawnMaxMultiplier = 1
 GroupSizeMinMultiplier = 1
 GroupSizeMaxMultiplier = 1
-SpawnFrequencyMultiplier = 0.95
+SpawnFrequencyMultiplier = 0.90
 
 [SHEEP_TW]
 PrefabName = Sheep_TW
@@ -611,7 +611,7 @@ Enable = true
 SpawnMaxMultiplier = 1
 GroupSizeMinMultiplier = 1
 GroupSizeMaxMultiplier = 1
-SpawnFrequencyMultiplier = 0.95
+SpawnFrequencyMultiplier = 0.90
 
 [BLACKBEAR_TW]
 PrefabName = BlackBear_TW
@@ -619,7 +619,7 @@ Enable = true
 SpawnMaxMultiplier = 1
 GroupSizeMinMultiplier = 1
 GroupSizeMaxMultiplier = 1
-SpawnFrequencyMultiplier = 0.95
+SpawnFrequencyMultiplier = 0.90
 
 [GDANCIENTSHAMAN_TW]
 PrefabName = GDAncientShaman_TW
@@ -683,7 +683,7 @@ Enable = true
 SpawnMaxMultiplier = 1
 GroupSizeMinMultiplier = 1
 GroupSizeMaxMultiplier = 1
-SpawnFrequencyMultiplier = 0.95
+SpawnFrequencyMultiplier = 0.90
 
 [FENRINGMAGE_TW]
 PrefabName = FenringMage_TW
@@ -699,7 +699,7 @@ Enable = true
 SpawnMaxMultiplier = 1
 GroupSizeMinMultiplier = 1
 GroupSizeMaxMultiplier = 1
-SpawnFrequencyMultiplier = 0.95
+SpawnFrequencyMultiplier = 0.90
 
 [GOBLINMAGE_TW]
 PrefabName = GoblinMage_TW

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
@@ -247,3 +247,100 @@ TemplateId = FrostWyrm
 
 [WorldSpawner.684.CreatureLevelAndLootControl]
 ConditionWorldLevelMin = 7
+[WorldSpawner.685]
+Name = Lox Calf
+PrefabName = Lox_Calf
+Biomes = Plains
+Enabled = true
+MaxSpawned = 1
+SpawnInterval = 1200
+SpawnChance = 3.75
+
+[WorldSpawner.685.CreatureLevelAndLootControl]
+ConditionWorldLevelMin = 5
+
+[WorldSpawner.686]
+Name = Wolf Cub
+PrefabName = Wolf_cub
+Biomes = Mountain
+Enabled = true
+MaxSpawned = 1
+SpawnInterval = 1200
+SpawnChance = 3.75
+SpawnDuringDay = false
+SpawnDuringNight = true
+
+[WorldSpawner.686.CreatureLevelAndLootControl]
+ConditionWorldLevelMin = 4
+
+[WorldSpawner.687]
+Name = Piggy
+PrefabName = Boar_piggy
+Biomes = Meadows
+Enabled = true
+MaxSpawned = 1
+SpawnInterval = 1200
+SpawnChance = 3.75
+
+[WorldSpawner.687.CreatureLevelAndLootControl]
+ConditionWorldLevelMin = 0
+
+[WorldSpawner.688]
+Name = Fox Cub
+PrefabName = FoxCub_TW
+Biomes = Meadows
+Enabled = true
+MaxSpawned = 1
+SpawnInterval = 1200
+SpawnChance = 3.75
+
+[WorldSpawner.688.CreatureLevelAndLootControl]
+ConditionWorldLevelMin = 0
+
+[WorldSpawner.689]
+Name = Razorback Piglet
+PrefabName = RazorbackPiggy_TW
+Biomes = Meadows, BlackForest
+Enabled = true
+MaxSpawned = 1
+SpawnInterval = 1200
+SpawnChance = 3.75
+
+[WorldSpawner.689.CreatureLevelAndLootControl]
+ConditionWorldLevelMin = 1
+
+[WorldSpawner.690]
+Name = Black Bear Cub
+PrefabName = BlackBearCub_TW
+Biomes = BlackForest
+Enabled = true
+MaxSpawned = 1
+SpawnInterval = 1200
+SpawnChance = 3.75
+
+[WorldSpawner.690.CreatureLevelAndLootControl]
+ConditionWorldLevelMin = 2
+
+[WorldSpawner.691]
+Name = Grizzly Cub
+PrefabName = GrizzlyBearCub_TW
+Biomes = Mountain
+Enabled = true
+MaxSpawned = 1
+SpawnInterval = 1200
+SpawnChance = 3.75
+
+[WorldSpawner.691.CreatureLevelAndLootControl]
+ConditionWorldLevelMin = 4
+
+[WorldSpawner.692]
+Name = Prowler Cub
+PrefabName = ProwlerCub_TW
+Biomes = Plains
+Enabled = true
+MaxSpawned = 1
+SpawnInterval = 1200
+SpawnChance = 3.75
+
+[WorldSpawner.692.CreatureLevelAndLootControl]
+ConditionWorldLevelMin = 5


### PR DESCRIPTION
## Summary
- Spawn Fox cubs, Razorback piglets, Black Bear cubs, Grizzly cubs, and Prowler cubs with biome-appropriate world-level gating.
- Lower adult spawn frequencies for Foxes, Razorbacks, Black Bears, Grizzlies, and Prowlers to keep performance overhead in check.
- Record new juvenile spawn logic in AGENTS memory.

## Testing
- `python List_Important_files.py both` *(fails: No such file or directory)*
- `pre-commit run --files .continue/AGENTS.md Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.simple.cfg Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_6893dafd41dc83318c40479cc433a801