### PR TITLE
Balance run skill buffs

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -421,3 +421,4 @@ git commit -m "Add/Update: [specific mod] configuration files"
 - Added prefab name parser script to extract internal and localized names from VNEI exports.
 - Added juvenile world spawns for Boar piggies, Wolf cubs, and Lox calves with reduced adult spawn frequencies to limit overhead.
 - Added juvenile world spawns for Fox cubs, Razorback piglets, Black Bear cubs, Grizzly cubs, and Prowler cubs with matched world-level gating and further reduced adult spawn frequencies.
+- Tuned Run skill balance: reduced run stamina reductions and speed bonuses in seasonal and potion configs to keep late-game mobility in check.

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/com.odinplus.potionsplus.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/com.odinplus.potionsplus.cfg
@@ -585,7 +585,7 @@ Jump Stamina Usage Factor = 0.75
 # Setting type: Single
 # Default value: 0.75
 # Acceptable value range: From 0 to 1
-Run Stamina Usage Factor = 0.75
+Run Stamina Usage Factor = 0.85
 
 ## Stamina regeneration factor from the Flask of Second Wind effect.
 # Setting type: Single

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/shudnal.Seasons/Default settings/Custom stats.json
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/shudnal.Seasons/Default settings/Custom stats.json
@@ -39,7 +39,7 @@
     "m_healthPerTick": 0.0,
     "m_healthHitType": "",
     "m_staminaDrainPerSec": 0.0,
-    "m_runStaminaDrainModifier": -0.1,
+    "m_runStaminaDrainModifier": -0.05,
     "m_jumpStaminaUseModifier": -0.1,
     "m_healthRegenMultiplier": 1.1,
     "m_staminaRegenMultiplier": 1.0,

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_Potion_hasty.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_Potion_hasty.yml
@@ -72,7 +72,7 @@ SeData:
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: Run
-  m_skillLevelModifier: 10
+  m_skillLevelModifier: 5
   m_skillLevel2: None
   m_skillLevelModifier2: 0
   m_mods: []
@@ -81,7 +81,7 @@ SeData:
   m_noiseModifier: 0
   m_stealthModifier: 0
   m_addMaxCarryWeight: 0
-  m_speedModifier: 0.15
+  m_speedModifier: 0.10
   m_jumpModifier: &o0
     x: 0
     y: 0

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_WindRun_JH.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_WindRun_JH.yml
@@ -66,7 +66,7 @@ SeData:
   m_staminaOverTime: 0
   m_staminaOverTimeDuration: 0
   m_staminaDrainPerSec: 0
-  m_runStaminaDrainModifier: -0.10
+  m_runStaminaDrainModifier: -0.05
   m_jumpStaminaUseModifier: 0
   m_attackStaminaUseModifier: 0
   m_blockStaminaUseModifier: 0
@@ -83,7 +83,7 @@ SeData:
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: Run
-  m_skillLevelModifier: 5
+  m_skillLevelModifier: 3
   m_skillLevel2: None
   m_skillLevelModifier2: 0
   m_mods: []


### PR DESCRIPTION
## Summary
- tune Run stamina cost reduction in Flask of Second Wind to avoid trivial sprinting
- cut hasty potion and Wind Run skill bonuses for steadier progression
- reduce seasonal Run stamina reduction in Summer

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6893fd76a62c8331b558056d23a53124