### PR TITLE
Update: Ranching skill configuration

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -388,6 +388,7 @@ git commit -m "Add/Update: [specific mod] configuration files"
 - Restored Burial-chamber chest loot by adding missing `[TreasureChest_forestcrypt]` block and setting SurtlingCore weight to `1`.
 - Added Drop That chest entries for Hildir quest and Deep North/Muspelheim chests to restore loot generation.
 - Switched CLLC creature scaling to use BossesKilled and set world level day thresholds to 9999 to disable time-based progression.
+- Tweaked Ranching skill config: faster taming at high levels, later feature unlocks, and small death XP loss.
 
 ---
 

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.ranching.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.ranching.cfg
@@ -21,25 +21,25 @@ Item Drop Factor = 2
 # Setting type: Single
 # Default value: 2
 # Acceptable value range: From 1 to 10
-Taming Factor = 2
+Taming Factor = 3
 
 ## Minimum required skill level to see when tamed creatures will become hungry again. 0 is disabled.
 # Setting type: Int32
 # Default value: 10
 # Acceptable value range: From 0 to 100
-Food Level Requirement = 10
+Food Level Requirement = 15
 
 ## Minimum required skill level to calm nearby taming creatures. 0 is disabled.
 # Setting type: Int32
 # Default value: 20
 # Acceptable value range: From 0 to 100
-Calming Level Requirement = 20
+Calming Level Requirement = 30
 
 ## Minimum required skill level to get pregnancy related information of tame creatures. 0 is disabled.
 # Setting type: Int32
 # Default value: 40
 # Acceptable value range: From 0 to 100
-Pregnancy Level Requirement = 40
+Pregnancy Level Requirement = 60
 
 [3 - Other]
 
@@ -53,5 +53,5 @@ Skill Experience Gain Factor = 0.6
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Skill Experience Loss = 0
+Skill Experience Loss = 2
 


### PR DESCRIPTION
## Summary
- Increase ranching taming speed scaling to 3x
- Delay hunger, calming, and pregnancy info unlocks to levels 15/30/60
- Apply small death XP loss and document change in AGENTS

## Testing
- `python -m py_compile scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6893fd90e5b48331aff6f1b8fc831374