### PR TITLE
Balance Pack Horse carry weight scaling

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -421,3 +421,4 @@ git commit -m "Add/Update: [specific mod] configuration files"
 - Added prefab name parser script to extract internal and localized names from VNEI exports.
 - Added juvenile world spawns for Boar piggies, Wolf cubs, and Lox calves with reduced adult spawn frequencies to limit overhead.
 - Added juvenile world spawns for Fox cubs, Razorback piglets, Black Bear cubs, Grizzly cubs, and Prowler cubs with matched world-level gating and further reduced adult spawn frequencies.
+- Tuned Pack Horse skill to use a 0.75 effect factor, curbing late-game carry weight inflation.

--- a/RelicheimBaseConfig/config/org.bepinex.plugins.packhorse.cfg
+++ b/RelicheimBaseConfig/config/org.bepinex.plugins.packhorse.cfg
@@ -13,7 +13,7 @@ Skill gain factor = 0.5
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill effect factor = 1
+Skill effect factor = 0.75
 
 ## How much experience to lose on death.
 # Setting type: Int32

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.packhorse.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.packhorse.cfg
@@ -13,7 +13,7 @@ Skill gain factor = 0.5
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill effect factor = 1
+Skill effect factor = 0.75
 
 ## How much experience to lose on death.
 # Setting type: Int32


### PR DESCRIPTION
## Summary
- lower Pack Horse skill effect multiplier to soften late-game carry weight growth
- record Pack Horse tuning in AGENTS working memory

## Testing
- `pytest` (no tests discovered)


------
https://chatgpt.com/codex/tasks/task_e_6893fdcf62ac8331ac79dec0fdbb774d