### PR TITLE
Balance Foraging skill progression

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -388,6 +388,7 @@ git commit -m "Add/Update: [specific mod] configuration files"
 - Restored Burial-chamber chest loot by adding missing `[TreasureChest_forestcrypt]` block and setting SurtlingCore weight to `1`.
 - Added Drop That chest entries for Hildir quest and Deep North/Muspelheim chests to restore loot generation.
 - Switched CLLC creature scaling to use BossesKilled and set world level day thresholds to 9999 to disable time-based progression.
+- Increased Foraging yield factor to 3 and XP gain factor to 0.6 for better late-game resource scaling.
 
 ---
 

--- a/RelicheimBaseConfig/config/org.bepinex.plugins.foraging.cfg
+++ b/RelicheimBaseConfig/config/org.bepinex.plugins.foraging.cfg
@@ -23,7 +23,7 @@ Foraging Scope = Foraging
 # Setting type: Single
 # Default value: 2
 # Acceptable value range: From 1 to 5
-Foraging Yield Factor = 2
+Foraging Yield Factor = 3
 
 ## Skill level required to see a timer when pickables will respawn. 0 is disabled.
 # Setting type: Int32
@@ -49,7 +49,7 @@ Multiplier for Respawn Speed = 2
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill Experience Gain Factor = 0.5
+Skill Experience Gain Factor = 0.6
 
 ## How much experience to lose in the foraging skill on death.
 # Setting type: Int32

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.foraging.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.foraging.cfg
@@ -23,7 +23,7 @@ Foraging Scope = Foraging
 # Setting type: Single
 # Default value: 2
 # Acceptable value range: From 1 to 5
-Foraging Yield Factor = 2
+Foraging Yield Factor = 3
 
 ## Skill level required to see a timer when pickables will respawn. 0 is disabled.
 # Setting type: Int32
@@ -49,7 +49,7 @@ Multiplier for Respawn Speed = 2
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill Experience Gain Factor = 0.5
+Skill Experience Gain Factor = 0.6
 
 ## How much experience to lose in the foraging skill on death.
 # Setting type: Int32


### PR DESCRIPTION
## Summary
- Increase Foraging yield factor to 3 for stronger late-game gathering
- Raise Foraging XP gain factor to 0.6 to smooth early progression
- Record Foraging balance changes in AGENTS memory

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6893fd9ffd388331be1541a4758c9b17