### PR TITLE
Balance lumberjacking progression

### DIFF
--- a/RelicheimBaseConfig/config/org.bepinex.plugins.lumberjacking.cfg
+++ b/RelicheimBaseConfig/config/org.bepinex.plugins.lumberjacking.cfg
@@ -13,7 +13,7 @@ Lock Configuration = On
 # Setting type: Single
 # Default value: 2
 # Acceptable value range: From 1 to 5
-Tree item yield modifier at level 100 = 1.5
+Tree item yield modifier at level 100 = 1.8
 
 ## Damage dealt to trees will be modified by this value at skill level 100.
 # Setting type: Single
@@ -31,7 +31,7 @@ Tree fall damage modifier at level 100 = 0.3
 # Setting type: Single
 # Default value: 1.1
 # Acceptable value range: From 1 to 2
-Movement speed modifier in forests at level 100 = 1.5
+Movement speed modifier in forests at level 100 = 1.3
 
 [2 - Other]
 

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.lumberjacking.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.lumberjacking.cfg
@@ -13,7 +13,7 @@ Lock Configuration = On
 # Setting type: Single
 # Default value: 2
 # Acceptable value range: From 1 to 5
-Tree item yield modifier at level 100 = 1.5
+Tree item yield modifier at level 100 = 1.8
 
 ## Damage dealt to trees will be modified by this value at skill level 100.
 # Setting type: Single
@@ -31,7 +31,7 @@ Tree fall damage modifier at level 100 = 0.3
 # Setting type: Single
 # Default value: 1.1
 # Acceptable value range: From 1 to 2
-Movement speed modifier in forests at level 100 = 1.5
+Movement speed modifier in forests at level 100 = 1.3
 
 [2 - Other]
 


### PR DESCRIPTION
## Summary
- Increase lumberjacking tree yield bonus at level 100 to 1.8
- Reduce forest movement speed bonus at level 100 to 1.3

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6893fd96c81c83318332ae2f288e365b