### PR TITLE
Reduce farming XP gain factor to 0.6

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -378,7 +378,7 @@ git commit -m "Add/Update: [specific mod] configuration files"
 
 ## 🆕 Recent Config Updates
 - Removed event boss loot sections (TempestNeck, Dragon, MagmaGolem, SeekerQueen, RoyalLox, AvalancheDrake, CoinTroll, WeaverQueen, FrostWyrm) from central drop table
-- Enabled biome enforcement in PlantEverything and reduced Farming XP gain factor to 0.6.
+- Enabled biome enforcement in PlantEverything and reduced Farming XP gain factor to 0.6 in both player and base configs.
 - Added Frost Dragon world spawn in DeepNorth with SnowStorm condition and altitude >= 100.
 - Introduced FrostDragon boss entry featuring frost breath and world-level scaling.
 - Created Dragon loot table dropping FrostScale, Silver, and a Legendary Weapon Schematic.

--- a/RelicheimBaseConfig/config/org.bepinex.plugins.farming.cfg
+++ b/RelicheimBaseConfig/config/org.bepinex.plugins.farming.cfg
@@ -65,7 +65,7 @@ Random Rotation = Off
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill Experience Gain Factor = 1.25
+Skill Experience Gain Factor = 0.6
 
 ## How much experience to lose in the farming skill on death.
 # Setting type: Int32

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.farming.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.farming.cfg
@@ -65,7 +65,7 @@ Random Rotation = Off
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill Experience Gain Factor = 1.25
+Skill Experience Gain Factor = 0.6
 
 ## How much experience to lose in the farming skill on death.
 # Setting type: Int32


### PR DESCRIPTION
## Summary
- Reduce Farming skill XP gain factor to 0.6 in player and base configs
- Document change in project AGENTS.md

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894bdb39518833185d38df344127f91