### PR TITLE
Increase Pack Horse skill gain

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -425,4 +425,5 @@ git commit -m "Add/Update: [specific mod] configuration files"
 - Added juvenile world spawns for Boar piggies, Wolf cubs, and Lox calves with reduced adult spawn frequencies to limit overhead.
 - Added juvenile world spawns for Fox cubs, Razorback piglets, Black Bear cubs, Grizzly cubs, and Prowler cubs with matched world-level gating and further reduced adult spawn frequencies.
 - Tuned Pack Horse skill to use a 0.75 effect factor, curbing late-game carry weight inflation.
+- Raised Pack Horse skill gain factor to 0.75 for faster leveling.
 - Tuned Run skill balance: reduced run stamina reductions and speed bonuses in seasonal and potion configs to keep late-game mobility in check.

--- a/RelicheimBaseConfig/config/org.bepinex.plugins.packhorse.cfg
+++ b/RelicheimBaseConfig/config/org.bepinex.plugins.packhorse.cfg
@@ -7,7 +7,7 @@
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill gain factor = 0.5
+Skill gain factor = 0.75
 
 ## The power of the skill, based on the default power.
 # Setting type: Single

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/org.bepinex.plugins.packhorse.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/org.bepinex.plugins.packhorse.cfg
@@ -7,7 +7,7 @@
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill gain factor = 0.5
+Skill gain factor = 0.75
 
 ## The power of the skill, based on the default power.
 # Setting type: Single

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/org.bepinex.plugins.packhorse.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/org.bepinex.plugins.packhorse.cfg
@@ -7,7 +7,7 @@
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill gain factor = 0.5
+Skill gain factor = 0.75
 
 ## The power of the skill, based on the default power.
 # Setting type: Single

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/org.bepinex.plugins.packhorse.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/org.bepinex.plugins.packhorse.cfg
@@ -7,7 +7,7 @@
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill gain factor = 0.5
+Skill gain factor = 0.75
 
 ## The power of the skill, based on the default power.
 # Setting type: Single

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/org.bepinex.plugins.packhorse.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/org.bepinex.plugins.packhorse.cfg
@@ -7,7 +7,7 @@
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill gain factor = 0.5
+Skill gain factor = 0.75
 
 ## The power of the skill, based on the default power.
 # Setting type: Single

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.packhorse.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.packhorse.cfg
@@ -7,7 +7,7 @@
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill gain factor = 0.5
+Skill gain factor = 0.75
 
 ## The power of the skill, based on the default power.
 # Setting type: Single


### PR DESCRIPTION
## Summary
- Raise Pack Horse skill gain factor from 0.5 to 0.75 across base and profile configs
- Document new Pack Horse leveling rate in project memory

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894bdc192a48331bb7598b78ab16c4d