### PR TITLE
Normalize skill XP rates and update documentation

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -36,15 +36,15 @@ Build a **RuneScape + Solo Leveling** inspired Valheim experience with RPG/MMO p
 ### **Vanilla Skill Experience Factors**
 - **Farming**: 0.6x (reduced for slower progression)
 - **Cooking**: 0.6x (reduced)
-- **Ranching**: 0.6x (reduced)
+- **Ranching**: 0.8x (boosted)
 - **Exploration**: 0.6x (reduced)
 - **Building**: 0.5x (reduced)
 - **Blacksmithing**: 0.5x (reduced)
-- **Foraging**: 0.5x (reduced)
+- **Foraging**: 0.6x (reduced)
 - **Lumberjacking**: 0.5x (reduced)
 - **Mining**: 0.5x (reduced)
-- **Sailing**: 0.5x (reduced)
-- **Pack Horse**: 0.5x (reduced)
+- **Sailing**: 0.4x (reduced)
+- **Pack Horse**: 0.75x (boosted)
 - **Tenacity**: 0.4x (reduced)
 - **Warfare Skills**: 1.0x (normal)
 - **Enchantment System**: 1.0x (normal)
@@ -389,8 +389,10 @@ git commit -m "Add/Update: [specific mod] configuration files"
 - Added Drop That chest entries for Hildir quest and Deep North/Muspelheim chests to restore loot generation.
 - Switched CLLC creature scaling to use BossesKilled and set world level day thresholds to 9999 to disable time-based progression.
 - Increased Foraging yield factor to 3 and XP gain factor to 0.6 for better late-game resource scaling.
+- Raised Pack Horse skill XP gain factor to 0.75 to ease carry-weight grind.
+- Reduced Sailing skill XP gain factor to 0.4 to slow progression.
 - Tuned mining skill balance: reduced level 100 damage multiplier to 1.8, raised explosion level requirement to 50 with 2% chance, and cut Specializing mining speed bonus to 0.2.
-- Tweaked Ranching skill config: faster taming at high levels, later feature unlocks, and small death XP loss.
+- Tweaked Ranching skill config: faster taming at high levels, later feature unlocks, small death XP loss, and XP gain factor increased to 0.8.
 
 ---
 

--- a/RelicheimBaseConfig/config/org.bepinex.plugins.farming.cfg
+++ b/RelicheimBaseConfig/config/org.bepinex.plugins.farming.cfg
@@ -65,7 +65,7 @@ Random Rotation = Off
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill Experience Gain Factor = 1.25
+Skill Experience Gain Factor = 0.6
 
 ## How much experience to lose in the farming skill on death.
 # Setting type: Int32

--- a/RelicheimBaseConfig/config/org.bepinex.plugins.packhorse.cfg
+++ b/RelicheimBaseConfig/config/org.bepinex.plugins.packhorse.cfg
@@ -7,7 +7,7 @@
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill gain factor = 0.5
+Skill gain factor = 0.75
 
 ## The power of the skill, based on the default power.
 # Setting type: Single

--- a/RelicheimBaseConfig/config/org.bepinex.plugins.sailing.cfg
+++ b/RelicheimBaseConfig/config/org.bepinex.plugins.sailing.cfg
@@ -130,7 +130,7 @@ Ship Health Factor = 2
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill Experience Gain Factor = 0.5
+Skill Experience Gain Factor = 0.4
 
 ## How much experience to lose in the sailing skill on death.
 # Setting type: Int32

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.farming.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.farming.cfg
@@ -65,7 +65,7 @@ Random Rotation = Off
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill Experience Gain Factor = 1.25
+Skill Experience Gain Factor = 0.6
 
 ## How much experience to lose in the farming skill on death.
 # Setting type: Int32

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.packhorse.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.packhorse.cfg
@@ -7,7 +7,7 @@
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill gain factor = 0.5
+Skill gain factor = 0.75
 
 ## The power of the skill, based on the default power.
 # Setting type: Single

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.ranching.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.ranching.cfg
@@ -47,7 +47,7 @@ Pregnancy Level Requirement = 60
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill Experience Gain Factor = 0.6
+Skill Experience Gain Factor = 0.8
 
 ## How much experience to lose in the ranching skill on death.
 # Setting type: Int32


### PR DESCRIPTION
## Summary
- Lower sailing XP rate to 0.4 and document new progression
- Raise Pack Horse XP rate to 0.75 and increase Ranching to 0.8
- Set Farming XP rate to 0.6 across configs and update AGENTS memory

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6894bbc943148331aaa0fe4131438ca4