### PR TITLE
Improve Eitr regen progression

### DIFF
--- a/.continue/AGENTS.md
+++ b/.continue/AGENTS.md
@@ -391,10 +391,11 @@ git commit -m "Add/Update: [specific mod] configuration files"
 - Increased Foraging yield factor to 3 and XP gain factor to 0.6 for better late-game resource scaling.
 - Tuned mining skill balance: reduced level 100 damage multiplier to 1.8, raised explosion level requirement to 50 with 2% chance, and cut Specializing mining speed bonus to 0.2.
 - Tweaked Ranching skill config: faster taming at high levels, later feature unlocks, and small death XP loss.
+- Raised eitr regeneration multipliers across jerky foods (Neck 1.02, Fish 1.04, Serpent 1.06, Lox 1.08, Seeker 1.10) to create a progression and offset Staff of Major Healing eitr costs.
 
 ---
 
-**🎯 Remember**: This is a **comprehensive Valheim modding reference** focused on JewelHeim-RelicHeim. Every change impacts mod compatibility, user experience, and maintainability. **Progression balance is paramount**. 
+**🎯 Remember**: This is a **comprehensive Valheim modding reference** focused on JewelHeim-RelicHeim. Every change impacts mod compatibility, user experience, and maintainability. **Progression balance is paramount**.
 ## 🆕 Royal Lox Event
 - Added Harmony event hook (`RoyalLoxEvent.cs`) detecting 5-star Lox deaths and spawning an oversized replacement after a short delay.
 - Configured `spawn_that.world_spawners_advanced.cfg` with a `RoyalLoxEvent` trigger spawning scaled Lox in Plains grasslands.

--- a/RelicheimBaseConfig/config/wackysDatabase/Effects/SE_SetEffect_FishJerky.yml
+++ b/RelicheimBaseConfig/config/wackysDatabase/Effects/SE_SetEffect_FishJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.04
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: Swim

--- a/RelicheimBaseConfig/config/wackysDatabase/Effects/SE_SetEffect_LoxJerky.yml
+++ b/RelicheimBaseConfig/config/wackysDatabase/Effects/SE_SetEffect_LoxJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.08
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: None

--- a/RelicheimBaseConfig/config/wackysDatabase/Effects/SE_SetEffect_NeckJerky.yml
+++ b/RelicheimBaseConfig/config/wackysDatabase/Effects/SE_SetEffect_NeckJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.02
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: Swim

--- a/RelicheimBaseConfig/config/wackysDatabase/Effects/SE_SetEffect_SeekerJerky.yml
+++ b/RelicheimBaseConfig/config/wackysDatabase/Effects/SE_SetEffect_SeekerJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1.02
+  m_eitrRegenMultiplier: 1.10
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: None

--- a/RelicheimBaseConfig/config/wackysDatabase/Effects/SE_SetEffect_SerpentJerky.yml
+++ b/RelicheimBaseConfig/config/wackysDatabase/Effects/SE_SetEffect_SerpentJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.06
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: Swim

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/wackysDatabase/Effects/SE_SetEffect_FishJerky.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/wackysDatabase/Effects/SE_SetEffect_FishJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.04
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: Swim

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/wackysDatabase/Effects/SE_SetEffect_LoxJerky.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/wackysDatabase/Effects/SE_SetEffect_LoxJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.08
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: None

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/wackysDatabase/Effects/SE_SetEffect_NeckJerky.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/wackysDatabase/Effects/SE_SetEffect_NeckJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.02
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: Swim

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/wackysDatabase/Effects/SE_SetEffect_SeekerJerky.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/wackysDatabase/Effects/SE_SetEffect_SeekerJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1.02
+  m_eitrRegenMultiplier: 1.10
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: None

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/wackysDatabase/Effects/SE_SetEffect_SerpentJerky.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/wackysDatabase/Effects/SE_SetEffect_SerpentJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.06
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: Swim

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/wackysDatabase/Effects/SE_SetEffect_FishJerky.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/wackysDatabase/Effects/SE_SetEffect_FishJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.04
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: Swim

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/wackysDatabase/Effects/SE_SetEffect_LoxJerky.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/wackysDatabase/Effects/SE_SetEffect_LoxJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.08
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: None

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/wackysDatabase/Effects/SE_SetEffect_NeckJerky.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/wackysDatabase/Effects/SE_SetEffect_NeckJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.02
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: Swim

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/wackysDatabase/Effects/SE_SetEffect_SeekerJerky.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/wackysDatabase/Effects/SE_SetEffect_SeekerJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1.02
+  m_eitrRegenMultiplier: 1.10
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: None

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/wackysDatabase/Effects/SE_SetEffect_SerpentJerky.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/wackysDatabase/Effects/SE_SetEffect_SerpentJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.06
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: Swim

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/wackysDatabase/Effects/SE_SetEffect_FishJerky.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/wackysDatabase/Effects/SE_SetEffect_FishJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.04
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: Swim

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/wackysDatabase/Effects/SE_SetEffect_LoxJerky.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/wackysDatabase/Effects/SE_SetEffect_LoxJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.08
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: None

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/wackysDatabase/Effects/SE_SetEffect_NeckJerky.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/wackysDatabase/Effects/SE_SetEffect_NeckJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.02
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: Swim

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/wackysDatabase/Effects/SE_SetEffect_SeekerJerky.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/wackysDatabase/Effects/SE_SetEffect_SeekerJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1.02
+  m_eitrRegenMultiplier: 1.10
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: None

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/wackysDatabase/Effects/SE_SetEffect_SerpentJerky.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/wackysDatabase/Effects/SE_SetEffect_SerpentJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.06
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: Swim

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/wackysDatabase/Effects/SE_SetEffect_FishJerky.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/wackysDatabase/Effects/SE_SetEffect_FishJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.04
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: Swim

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/wackysDatabase/Effects/SE_SetEffect_LoxJerky.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/wackysDatabase/Effects/SE_SetEffect_LoxJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.08
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: None

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/wackysDatabase/Effects/SE_SetEffect_NeckJerky.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/wackysDatabase/Effects/SE_SetEffect_NeckJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.02
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: Swim

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/wackysDatabase/Effects/SE_SetEffect_SeekerJerky.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/wackysDatabase/Effects/SE_SetEffect_SeekerJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1.02
+  m_eitrRegenMultiplier: 1.10
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: None

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/wackysDatabase/Effects/SE_SetEffect_SerpentJerky.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/wackysDatabase/Effects/SE_SetEffect_SerpentJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.06
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: Swim

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_SetEffect_FishJerky.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_SetEffect_FishJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.04
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: Swim

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_SetEffect_LoxJerky.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_SetEffect_LoxJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.08
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: None

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_SetEffect_NeckJerky.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_SetEffect_NeckJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.02
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: Swim

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_SetEffect_SeekerJerky.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_SetEffect_SeekerJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1.02
+  m_eitrRegenMultiplier: 1.10
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: None

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_SetEffect_SerpentJerky.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_SetEffect_SerpentJerky.yml
@@ -35,7 +35,7 @@ SeData:
   m_eitrOverTimeDuration: 0
   m_healthRegenMultiplier: 1
   m_staminaRegenMultiplier: 1
-  m_eitrRegenMultiplier: 1
+  m_eitrRegenMultiplier: 1.06
   m_raiseSkill: None
   m_raiseSkillModifier: 0
   m_skillLevel: Swim


### PR DESCRIPTION
## Summary
- increase eitr regeneration multipliers on jerkies from Neck to Seeker for tiered sustain
- document eitr food adjustments in AGENTS memory

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894c044795c83318cedb005eec501e6