### PR TITLE
Add cooldowns and tune healing-over-time effects

### DIFF
--- a/RelicheimBaseConfig/config/wackysDatabase/Effects/SE_Bandage1_JH.yml
+++ b/RelicheimBaseConfig/config/wackysDatabase/Effects/SE_Bandage1_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 50
+  m_healthOverTime: 25
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 25

--- a/RelicheimBaseConfig/config/wackysDatabase/Effects/SE_Bandage2_JH.yml
+++ b/RelicheimBaseConfig/config/wackysDatabase/Effects/SE_Bandage2_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 100
+  m_healthOverTime: 50
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 50

--- a/RelicheimBaseConfig/config/wackysDatabase/Effects/SE_Bandage_JH.yml
+++ b/RelicheimBaseConfig/config/wackysDatabase/Effects/SE_Bandage_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 25
+  m_healthOverTime: 10
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 0

--- a/RelicheimBaseConfig/config/wackysDatabase/Effects/SE_StaffofHOT2_JH.yml
+++ b/RelicheimBaseConfig/config/wackysDatabase/Effects/SE_StaffofHOT2_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 100
+  m_healthOverTime: 50
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 0

--- a/RelicheimBaseConfig/config/wackysDatabase/Effects/SE_StaffofHOT_JH.yml
+++ b/RelicheimBaseConfig/config/wackysDatabase/Effects/SE_StaffofHOT_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 50
+  m_healthOverTime: 25
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 0

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/wackysDatabase/Effects/SE_Bandage1_JH.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/wackysDatabase/Effects/SE_Bandage1_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 50
+  m_healthOverTime: 25
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 25

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/wackysDatabase/Effects/SE_Bandage2_JH.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/wackysDatabase/Effects/SE_Bandage2_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 100
+  m_healthOverTime: 50
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 50

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/wackysDatabase/Effects/SE_Bandage_JH.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/wackysDatabase/Effects/SE_Bandage_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 25
+  m_healthOverTime: 10
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 0

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/wackysDatabase/Effects/SE_StaffofHOT2_JH.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/wackysDatabase/Effects/SE_StaffofHOT2_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 100
+  m_healthOverTime: 50
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 0

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/wackysDatabase/Effects/SE_StaffofHOT_JH.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/wackysDatabase/Effects/SE_StaffofHOT_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 50
+  m_healthOverTime: 25
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 0

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/wackysDatabase/Effects/SE_Bandage1_JH.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/wackysDatabase/Effects/SE_Bandage1_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 50
+  m_healthOverTime: 25
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 25

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/wackysDatabase/Effects/SE_Bandage2_JH.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/wackysDatabase/Effects/SE_Bandage2_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 100
+  m_healthOverTime: 50
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 50

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/wackysDatabase/Effects/SE_Bandage_JH.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/wackysDatabase/Effects/SE_Bandage_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 25
+  m_healthOverTime: 10
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 0

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/wackysDatabase/Effects/SE_StaffofHOT2_JH.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/wackysDatabase/Effects/SE_StaffofHOT2_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 100
+  m_healthOverTime: 50
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 0

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/wackysDatabase/Effects/SE_StaffofHOT_JH.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/wackysDatabase/Effects/SE_StaffofHOT_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 50
+  m_healthOverTime: 25
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 0

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/wackysDatabase/Effects/SE_Bandage1_JH.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/wackysDatabase/Effects/SE_Bandage1_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 50
+  m_healthOverTime: 25
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 25

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/wackysDatabase/Effects/SE_Bandage2_JH.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/wackysDatabase/Effects/SE_Bandage2_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 100
+  m_healthOverTime: 50
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 50

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/wackysDatabase/Effects/SE_Bandage_JH.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/wackysDatabase/Effects/SE_Bandage_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 25
+  m_healthOverTime: 10
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 0

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/wackysDatabase/Effects/SE_StaffofHOT2_JH.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/wackysDatabase/Effects/SE_StaffofHOT2_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 100
+  m_healthOverTime: 50
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 0

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/wackysDatabase/Effects/SE_StaffofHOT_JH.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/wackysDatabase/Effects/SE_StaffofHOT_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 50
+  m_healthOverTime: 25
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 0

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/wackysDatabase/Effects/SE_Bandage1_JH.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/wackysDatabase/Effects/SE_Bandage1_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 50
+  m_healthOverTime: 25
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 25

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/wackysDatabase/Effects/SE_Bandage2_JH.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/wackysDatabase/Effects/SE_Bandage2_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 100
+  m_healthOverTime: 50
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 50

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/wackysDatabase/Effects/SE_Bandage_JH.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/wackysDatabase/Effects/SE_Bandage_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 25
+  m_healthOverTime: 10
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 0

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/wackysDatabase/Effects/SE_StaffofHOT2_JH.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/wackysDatabase/Effects/SE_StaffofHOT2_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 100
+  m_healthOverTime: 50
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 0

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/wackysDatabase/Effects/SE_StaffofHOT_JH.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/wackysDatabase/Effects/SE_StaffofHOT_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 50
+  m_healthOverTime: 25
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 0

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_Bandage1_JH.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_Bandage1_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 50
+  m_healthOverTime: 25
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 25

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_Bandage2_JH.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_Bandage2_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 100
+  m_healthOverTime: 50
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 50

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_Bandage_JH.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_Bandage_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 25
+  m_healthOverTime: 10
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 0

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_StaffofHOT2_JH.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_StaffofHOT2_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 100
+  m_healthOverTime: 50
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 0

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_StaffofHOT_JH.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackysDatabase/Effects/SE_StaffofHOT_JH.yml
@@ -42,13 +42,13 @@ StartEffect_PLUS:
   m_scale: false
   m_childTransform: ''
 StopEffect_PLUS: []
-Cooldown: 0
+Cooldown: 60
 ActivationAnimation: gpower
 SeData:
   m_tickInterval: 0
   m_healthPerTickMinHealthPercentage: 0
   m_healthPerTick: 0
-  m_healthOverTime: 50
+  m_healthOverTime: 25
   m_healthOverTimeDuration: 10
   m_healthOverTimeInterval: 1
   m_staminaOverTime: 0


### PR DESCRIPTION
## Summary
- Prevent bandage spamming by adding 60s cooldowns and lowering healing-over-time
- Limit Staff of Healing spamming via 60s internal cooldowns and reduced healing output

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6894c080ff2c83318518f9debc1bfa0a