### PR TITLE
Update equipment upgrade stats

### DIFF
--- a/equipment_upgrade_curves.csv
+++ b/equipment_upgrade_curves.csv
@@ -1,6 +1,6 @@
 item_name,type,base_armor_or_damage,upgrade_level,armor_or_damage_at_level,resistances,wl_min,wl_max,notes
 CrossbowEikthyr_TW,weapon_pierce+lightning,"Pierce 38, Lightning 3",1,"Pierce 41, Lightning 5",-,2,3,"Item file: .../Items/_RelicHeimWDB2.0/zOther/Therzie/Item_CrossbowEikthyr_TW.yml (per-level: +3 pierce, +2 lightning; maxQuality=12)"
 CrossbowEikthyr_TW,weapon_pierce+lightning,"Pierce 38, Lightning 3",5,"Pierce 50, Lightning 11",-,2,3,"Same pattern"
-CrossbowEikthyr_TW,weapon_pierce+lightning,"Pierce 38, Lightning 3",10,"Pierce 68, Lightning 23",-,2,3,"Same pattern"
-GreatbowModer_TW,weapon_frost+pierce,"Frost ~75, Pierce ~32",1,"Frost ~82, Pierce ~36",-,4,6,"Representative; see .../Items/_RelicHeimWDB2.0/Weapons_Bows/Item_GreatbowModer_TW.yml"
-Generic_T5_Shield,shield_block,"Block ~90",1,"Block ~95",+elemental resist,6,7,"Representative shield curve; per-level small block gains"
+CrossbowEikthyr_TW,weapon_pierce+lightning,"Pierce 38, Lightning 3",10,"Pierce 65, Lightning 21",-,2,3,"Same pattern"
+GreatbowModer_TW,weapon_frost+pierce,"Frost 60, Pierce 25",1,"Frost 66, Pierce 29",-,4,6,"Item file: .../Items/_RelicHeimWDB2.0/Weapons_Bows/Item_GreatbowModer_TW.yml (per-level: +6 frost, +4 pierce; maxQuality=4)"
+Generic_T5_Shield,shield_block,"Block 90",1,"Block 95",+elemental resist,6,7,"Representative shield curve; per-level small block gains"


### PR DESCRIPTION
## Summary
- Fix CrossbowEikthyr level-10 stats to 65 pierce and 21 lightning
- Replace GreatbowModer placeholder values with exact frost and pierce damage
- Normalize generic T5 shield block values

## Testing
- `python - <<'PY'
import csv,sys
with open('equipment_upgrade_curves.csv') as f:
    rows=list(csv.reader(f))
print('rows',len(rows))
for r in rows:
    if len(r)!=9:
        print('row len',len(r),r)
PY`


------
https://chatgpt.com/codex/tasks/task_e_6897d079e47c8331a13265628b9246c8