### PR TITLE
Align Cloudberry trade with dragon requirement

### DIFF
--- a/merchant_quest_economy.csv
+++ b/merchant_quest_economy.csv
@@ -1,6 +1,6 @@
 vendor_name,item_name,wl_min,wl_max,buy_price,sell_price,daily_limit,quest_reward,quest_cooldown_days,notes
 PlainsTavern1_Trader,DragonEgg,4,6,500,,1,,,"File: Valheim/profiles/Dogeheim_Player/BepInEx/config/shudnal.TradersExtended.MWL_PlainsTavern1_Trader.sell.json (requires defeated_dragon)"
 PlainsTavern1_Trader,BlackCore,6,7,300,,2,,,"Same file (requires defeated_queen)"
-PlainsTavern1_Trader,Cloudberry,5,6,4,,20,,,"Requires defeated_goblinking"
+PlainsTavern1_Trader,Cloudberry,4,6,4,,20,,,"Requires defeated_dragon"
 PlainsTavern1_Trader,Amber,3,4,100,,10,,,"Requires defeated_bonemass"
 PlainsTavern1_Trader,Coins,0,7,,1,500,,,"Representative buyback; not explicit in file"


### PR DESCRIPTION
## Summary
- Update Cloudberry entry in merchant quest data to require defeating Moder and lower world-level gate
- Confirm trader config Cloudberry listing uses `requiredGlobalKey: defeated_dragon`
- Checked DragonEgg, BlackCore, and Amber entries for consistency with their JSON sources

## Testing
- `python - <<'PY'
import csv
with open('merchant_quest_economy.csv', newline='') as f:
    rows = list(csv.reader(f))
print('rows', len(rows))
PY`


------
https://chatgpt.com/codex/tasks/task_e_6897d07c0b048331a78d7ba90f404cb4