### PR TITLE
chore: update spawn world samples for time-of-day

### DIFF
--- a/spawn_world_samples.csv
+++ b/spawn_world_samples.csv
@@ -1,7 +1,7 @@
 biome,creature_prefab,wl_min,wl_max,time_of_day,weather,group_size_min,group_size_max,spawn_chance_pct,spawn_interval_s,max_spawned,notes
-Meadows,TempestNeck,0,1,Night,Thunderstorm,1,1,37.5,1200,1,"Spawn That advanced [WorldSpawner.676]; TemplateId=TempestNeck; Chance 37.5%"
+Meadows,TempestNeck,0,1,Any,Thunderstorm,1,1,37.5,1200,1,"Spawn That advanced [WorldSpawner.676]; TemplateId=TempestNeck; Chance 37.5%"
 BlackForest,CoinTroll,2,3,Any,Any,1,1,7.5,1200,1,"[WorldSpawner.675] WL≥2"
-Ocean,TempestSerpent,3,7,Night,Thunderstorm,1,1,37.5,1800,1,"[WorldSpawner.678] WL≥3; LevelMin/Max=6"
+Ocean,TempestSerpent,3,7,Any,ThunderStorm,1,1,37.5,1800,1,"[WorldSpawner.678] WL≥3; LevelMin/Max=6"
 Plains,RoyalLox,5,6,Any,Any,1,1,75,1200,1,"[WorldSpawner.679] RequiresGlobalKey=RoyalLoxEvent"
-DeepNorth,FrostWyrm,7,7,Night,SnowStorm,1,1,7.5,1200,1,"[WorldSpawner.684] WL≥7"
-DeepNorth,Dragon,7,7,Night,SnowStorm,1,1,7.5,1200,1,"[WorldSpawner.674] WL≥7"
+DeepNorth,FrostWyrm,7,7,Any,SnowStorm,1,1,7.5,1200,1,"[WorldSpawner.684] WL≥7"
+DeepNorth,Dragon,7,7,Any,SnowStorm,1,1,7.5,1200,1,"[WorldSpawner.674] WL≥7"


### PR DESCRIPTION
## Summary
- correct time_of_day values for TempestNeck, TempestSerpent, FrostWyrm, and Dragon entries
- align TempestSerpent weather with config

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897d07c55ac8331b9fabc8ed84c463d