### PR TITLE
Remove catch-up skill placeholders

### DIFF
--- a/Valheim_Help_Docs/Summaries/Gameplay_Mod_Walkthrough.md
+++ b/Valheim_Help_Docs/Summaries/Gameplay_Mod_Walkthrough.md
@@ -17,8 +17,8 @@ The primary RPG layer.  Gain experience from combat and activities to level up.
 
 ### SmartSkills
 Enhances the vanilla skill system.
-- Lost skill levels regain 50% faster until your previous peak is reached.
-- Weapon skills below your highest weapon skill receive a 50% catch‑up bonus.
+- **Skill Recovery Bonus** – lost skill levels regain XP 50% faster until your previous peak is reached.
+- **Weapon Catch-up Bonus** – weapon skills below your highest weapon skill earn 50% extra XP until they catch up.
 - Swimming and Sneak have additional XP bonuses.
 
 ### EpicLoot

--- a/skills_xp_multipliers.csv
+++ b/skills_xp_multipliers.csv
@@ -17,5 +17,3 @@ Building,0.5
 BloodMagic,1.0
 Swimming,2.0
 Sneak,1.1
-Weapon_Catchup_Bonus,1.5,"SmartSkills: Skill catch up bonus = 50%"
-Skill_Recovery_Bonus,1.5,"SmartSkills: Skill recovery bonus = 50%" 


### PR DESCRIPTION
## Summary
- drop Weapon_Catchup_Bonus and Skill_Recovery_Bonus from skill XP multipliers
- document SmartSkills recovery and catch-up bonuses in gameplay guide

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897d07efca08331810993dfb208fb7c