### PR TITLE
Separate boss star scaling and normalize star identifiers

### DIFF
--- a/boss_star_scaling.csv
+++ b/boss_star_scaling.csv
@@ -1,0 +1,7 @@
+stars,hp_mult,dmg_mult,loot_bonus_mult,spawn_weight_mult,notes
+0,1.0,1.0,1.0,1.0,"Base boss scaling; +20% HP/DMG and +50% loot per star"
+1,1.2,1.2,1.5,0.8,"Low-star boss (rare)"
+2,1.4,1.4,2.0,0.6,"Low-star boss (rare)"
+3,1.6,1.6,2.5,0.4,"Mid-star boss (rare)"
+4,1.8,1.8,3.0,0.2,"Standard boss star; ~80% chance"
+5,2.0,2.0,3.5,0.1,"High boss star; ~20% chance"

--- a/star_scaling.csv
+++ b/star_scaling.csv
@@ -3,4 +3,4 @@ stars,hp_mult,dmg_mult,loot_bonus_mult,spawn_weight_mult,notes
 1,1.5,1.35,2.0,0.8,"Per-star from CLLC: +50% HP, +35% DMG; loot per star 100% for creatures"
 2,2.25,1.82,3.0,0.6,"Derived multiplicatively; fewer spawns"
 3,3.38,2.46,4.0,0.4,"High-star rare"
-Boss(4★),2.0,1.8,1.5,0.2,"Boss star chances set 80% 4★, 20% 5★; health/dmg per star 20% (boss section)"
+4,5.06,3.32,5.0,0.2,"Derived multiplicatively; bosses use boss_star_scaling.csv"


### PR DESCRIPTION
## Summary
- Replace non-numeric `Boss(4★)` entry with numeric star value in `star_scaling.csv`
- Move boss-specific multipliers into new `boss_star_scaling.csv` with 20% HP/DMG and 50% loot per star

## Testing
- `python - <<'PY'
import csv
for fname in ['star_scaling.csv','boss_star_scaling.csv']:
    with open(fname) as f:
        reader = csv.DictReader(f)
        rows = list(reader)
        all_numeric = True
        for r in rows:
            try:
                float(r['stars'])
            except ValueError:
                all_numeric = False
                break
        print(f"{fname}: all_numeric={all_numeric}, rows={len(rows)}")
PY`


------
https://chatgpt.com/codex/tasks/task_e_6897d08011208331bf32d76bd31d8fd8