### PR TITLE
Reduce XP loss on death

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.EpicMMOSystem.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.EpicMMOSystem.cfg
@@ -70,12 +70,12 @@ GroupExp = 0.7
 ## Minimum Loss Exp if player death, default 5% loss [Synced with Server]
 # Setting type: Single
 # Default value: 0.05
-MinLossExp = 0.25
+MinLossExp = 0.05
 
 ## Maximum Loss Exp if player death, default 25% loss [Synced with Server]
 # Setting type: Single
 # Default value: 0.25
-MaxLossExp = 0.5
+MaxLossExp = 0.15
 
 ## Enabled exp loss [Synced with Server]
 # Setting type: Boolean


### PR DESCRIPTION
## Summary
- decrease minimum and maximum XP loss on death

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898b87195288331bc3f0385135f6e39