### PR TITLE
Gate world level progression by bosses

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.creaturelevelcontrol.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.creaturelevelcontrol.cfg
@@ -98,7 +98,7 @@ Difficulty = Very_hard
 # Setting type: DifficultySecondFactor
 # Default value: BossesKilled
 # Acceptable values: None, Age_of_world, Distance, BossesKilled
-Second factor = Distance
+Second factor = BossesKilled
 
 ## Display circles on the map for distance from spawn option.
 # Setting type: Toggle
@@ -341,37 +341,37 @@ Damage gained per star for bosses (percentage) = 20
 ## Days needed to pass before your world gets to world level 1.
 # Setting type: Int32
 # Default value: 10
-World level 1 start (days) = 10
+World level 1 start (days) = 9999
 
 ## Days needed to pass before your world gets to world level 2.
 # Setting type: Int32
 # Default value: 25
-World level 2 start (days) = 25
+World level 2 start (days) = 9999
 
 ## Days needed to pass before your world gets to world level 3.
 # Setting type: Int32
 # Default value: 50
-World level 3 start (days) = 50
+World level 3 start (days) = 9999
 
 ## Days needed to pass before your world gets to world level 4.
 # Setting type: Int32
 # Default value: 100
-World level 4 start (days) = 100
+World level 4 start (days) = 9999
 
 ## Days needed to pass before your world gets to world level 5.
 # Setting type: Int32
 # Default value: 250
-World level 5 start (days) = 250
+World level 5 start (days) = 9999
 
 ## Days needed to pass before your world gets to world level 6.
 # Setting type: Int32
 # Default value: 400
-World level 6 start (days) = 500
+World level 6 start (days) = 9999
 
 ## Days needed to pass before your world gets to world level 7.
 # Setting type: Int32
 # Default value: 600
-World level 7 start (days) = 600
+World level 7 start (days) = 9999
 
 [5 - Custom level chances]
 


### PR DESCRIPTION
## Summary
- Progress world levels only when bosses are defeated by switching CLLC's second factor to `BossesKilled`
- Prevent day-based world level changes by setting Age of World thresholds to 9999 days

## Testing
- `python -m py_compile scripts/valheim_mod_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6898d6e3db608331a61860a4fc237e90