### PR TITLE
Adjust Black Forest spawn pacing

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.spawnarea_spawners.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.spawnarea_spawners.cfg
@@ -8,3 +8,7 @@
 #     4. Make your changes.
 # To find modded configs and change those, enable WriteConfigsToFile in 'spawn_that.cfg', and do as described above.
 
+[Spawner_GreydwarfNest]
+IdentifyByName = Spawner_GreydwarfNest
+SpawnInterval = 25
+

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
@@ -8,6 +8,76 @@
 #     4. Make your changes.
 # To find modded configs and change those, enable WriteSpawnTablesToFileAfterChanges in 'spawn_that.cfg', and do as described above.
 
+[WorldSpawner.16]
+Name = greydwarf DAY
+PrefabName = Greydwarf
+Biomes = BlackForest
+Enabled = true
+MaxSpawned = 3
+SpawnInterval = 300
+SpawnChance = 12
+SpawnDistance = 70
+GroupSizeMin = 1
+GroupSizeMax = 3
+GroupRadius = 10
+GroundOffset = 0.5
+SpawnDuringDay = true
+SpawnDuringNight = true
+SpawnInForest = true
+SpawnOutsideForest = true
+ConditionTiltMax = 35
+BiomeArea = 7
+SetFaction = ForestMonsters
+SetTryDespawnOnConditionsInvalid = true
+
+[WorldSpawner.30]
+Name =
+Biomes = BlackForest
+PrefabName = Troll
+Enabled = true
+HuntPlayer = false
+MaxSpawned = 1
+SpawnInterval = 900
+SpawnChance = 14.25
+SpawnDistance = 64
+GroupSizeMin = 1
+GroupSizeMax = 1
+GroupRadius = 3
+GroundOffset = 0.5
+SpawnDuringDay = true
+SpawnDuringNight = false
+SpawnInForest = true
+SpawnOutsideForest = true
+ConditionTiltMax = 35
+BiomeArea = -1
+SetTryDespawnOnConditionsInvalid = true
+
+[WorldSpawner.32001]
+Name =
+Biomes = BlackForest
+PrefabName = Troll
+Enabled = true
+HuntPlayer = false
+MaxSpawned = 1
+SpawnInterval = 900
+SpawnChance = 10.69
+SpawnDistance = 64
+GroupSizeMin = 1
+GroupSizeMax = 1
+GroupRadius = 3
+GroundOffset = 0.5
+SpawnDuringDay = false
+SpawnDuringNight = true
+SpawnInForest = true
+SpawnOutsideForest = true
+ConditionAltitudeMin = 0
+ConditionAltitudeMax = 1000
+ConditionTiltMin = 0
+ConditionTiltMax = 35
+ConditionDistanceToCenterMin = 1000
+SetTryDespawnOnConditionsInvalid = true
+SetFaction = Boss
+
 [WorldSpawner.666]
 Name = Mushroom Meadows
 PrefabName = MushroomMeadows_MP

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.Blackforest_Pack_2.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.Blackforest_Pack_2.cfg
@@ -29,36 +29,6 @@ Use Custom Loot YAML file = On
 # Setting type: String
 # Default value: BlackforestLoot3
 Name of Loot List = BlackforestPack2ForgeLoot1
-
-[10 - GuardTower1]
-
-## Amount of this location the game will attempt to place during world generation [Synced with Server]
-# Setting type: Int32
-# Default value: 5
-Spawn Quantity = 4
-
-## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
-# Setting type: Toggle
-# Default value: Off
-# Acceptable values: Off, On
-Use Custom Creature YAML file = On
-
-## The name of the creature list to use from warpalicious.More_World_Locations_CreatureLists.yml file [Synced with Server]
-# Setting type: String
-# Default value: BlackforestCreatures1
-Name of Creature List = BlackforestPack2Creatures2
-
-## When Off, location will use default loot. When On, location will select loot from the list in the warpalicious.More_World_Locations_LootLists.yml file in the BepInEx config folder [Synced with Server]
-# Setting type: Toggle
-# Default value: Off
-# Acceptable values: Off, On
-Use Custom Loot YAML file = On
-
-## The name of the loot list to use from warpalicious.More_World_Locations_LootLists.yml file [Synced with Server]
-# Setting type: String
-# Default value: BlackforestLoot3
-Name of Loot List = BlackforestPack2TowerLoot1
-
 [11 - RootRuins1]
 
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
@@ -87,36 +57,6 @@ Use Custom Loot YAML file = On
 # Setting type: String
 # Default value: BlackforestLoot1
 Name of Loot List = BlackforestPack2RuinsLoot1
-
-[12 - RootsTower1]
-
-## Amount of this location the game will attempt to place during world generation [Synced with Server]
-# Setting type: Int32
-# Default value: 20
-Spawn Quantity = 14
-
-## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
-# Setting type: Toggle
-# Default value: Off
-# Acceptable values: Off, On
-Use Custom Creature YAML file = On
-
-## The name of the creature list to use from warpalicious.More_World_Locations_CreatureLists.yml file [Synced with Server]
-# Setting type: String
-# Default value: BlackforestCreatures3
-Name of Creature List = BlackforestPack2Creatures2
-
-## When Off, location will use default loot. When On, location will select loot from the list in the warpalicious.More_World_Locations_LootLists.yml file in the BepInEx config folder [Synced with Server]
-# Setting type: Toggle
-# Default value: Off
-# Acceptable values: Off, On
-Use Custom Loot YAML file = On
-
-## The name of the loot list to use from warpalicious.More_World_Locations_LootLists.yml file [Synced with Server]
-# Setting type: String
-# Default value: BlackforestLoot2
-Name of Loot List = BlackforestPack2TowerLoot1
-
 [13 - RootsTower2]
 
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.More_World_Locations_CreatureLists.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.More_World_Locations_CreatureLists.yml
@@ -96,14 +96,14 @@ BlackforestCreatures2:
   - Greydwarf
   # Elite variants for premium materials (55% chance)
   - Greydwarf_Elite
-  - Greydwarf_Shaman
-  - Greydwarf_Elite
-  - Greydwarf_Shaman
-  - Greydwarf_Elite
-  - Greydwarf_Shaman
-  - Greydwarf_Elite
-  - Greydwarf_Shaman
-  - Greydwarf_Elite
+  - Greydwarf
+  - Greydwarf
+  - Greydwarf
+  - Greydwarf
+  - Greydwarf
+  - Greydwarf
+  - Greydwarf
+  - Greydwarf
   - Greydwarf_Shaman
   - Greydwarf_Elite
   - Greydwarf_Shaman
@@ -408,16 +408,14 @@ UndergroundRuinsCreatures1:
   # Maximum elite spawns for ultimate underground excitement (40% chance)
   - Greydwarf_Shaman
   - Greydwarf_Elite
-  - Greydwarf_Shaman
-  - Greydwarf_Elite
-  - Greydwarf_Shaman
-  - Greydwarf_Elite
-  - Greydwarf_Shaman
-  - Greydwarf_Elite
-  - Greydwarf_Shaman
-  - Greydwarf_Elite
-  - Greydwarf_Shaman
-  - Greydwarf_Elite 
+  - Greydwarf
+  - Greydwarf
+  - Greydwarf
+  - Greydwarf
+  - Greydwarf
+  - Greydwarf
+  - Greydwarf
+  - Greydwarf
 
 # Forbidden Catacombs - Swamp Biome Procedural Dungeon
 # Dual-section dungeon with thematic distinction between upper nobles and lower commoners


### PR DESCRIPTION
## Summary
- soften Greydwarf daytime spawns and slow Troll respawns
- slow Greydwarf nest trickle rate
- tone down elite density in Underground Ruins and trim overlapping Blackforest POIs

## Testing
- `python3 -m py_compile scripts/valheim_mod_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6898da597a188331aca8838a623eae72