### PR TITLE
Label Troll daytime world spawner

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
@@ -8,6 +8,9 @@
 #     4. Make your changes.
 # To find modded configs and change those, enable WriteSpawnTablesToFileAfterChanges in 'spawn_that.cfg', and do as described above.
 
+[WorldSpawner.30]
+Name = Troll Day
+
 [WorldSpawner.666]
 Name = Mushroom Meadows
 PrefabName = MushroomMeadows_MP


### PR DESCRIPTION
## Summary
- label world spawner 30 as Troll Day

## Testing
- `python -m py_compile scripts/valheim_mod_manager.py`
- `rg Troll -n Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg`


------
https://chatgpt.com/codex/tasks/task_e_6898e0c533948331aac51fb27c3270f9