### PR TITLE
Name Troll Night world spawner

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/_RelicHeimFiles/Drop,Spawn_That/spawn_that.world_spawners.zBase.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/_RelicHeimFiles/Drop,Spawn_That/spawn_that.world_spawners.zBase.cfg
@@ -30,7 +30,7 @@ SetTryDespawnOnConditionsInvalid=true
 SetFaction=Boss
 
 [WorldSpawner.32001]
-Name=
+Name=Troll Night
 Enabled=True
 Biomes=BlackForest
 PrefabName=Troll


### PR DESCRIPTION
## Summary
- Give world spawner 32001 a descriptive name `Troll Night`

## Testing
- `python -m py_compile scripts/valheim_mod_manager.py`
- `rg "Troll Night" Valheim/profiles/Dogeheim_Player/BepInEx/config/_RelicHeimFiles/Drop,Spawn_That/spawn_that.world_spawners.zBase.cfg`


------
https://chatgpt.com/codex/tasks/task_e_6898e0c714588331a4608bc8c934eff3