### PR TITLE
Adjust skill experience factors

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/ValheimEnchantmentSystem/kg.ValheimEnchantmentSystem.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/ValheimEnchantmentSystem/kg.ValheimEnchantmentSystem.cfg
@@ -196,7 +196,7 @@ Skill EXP Scroll S = 140
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill gain factor = 0.6
+Skill gain factor = 0.55
 
 ## The power of the skill, based on the default power.
 # Setting type: Single

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.blacksmithing.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.blacksmithing.cfg
@@ -113,7 +113,7 @@ Experience Reduction Factor = 0.5
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill Experience Gain Factor = 0.5
+Skill Experience Gain Factor = 0.65
 
 ## How much experience to lose in the blacksmithing skill on death.
 # Setting type: Int32

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.building.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.building.cfg
@@ -53,7 +53,7 @@ Stamina Reduction per Level = 1
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill Experience Gain Factor = 0.5
+Skill Experience Gain Factor = 0.80
 
 ## How much experience to lose in the building skill on death.
 # Setting type: Int32

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.cooking.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.cooking.cfg
@@ -85,7 +85,7 @@ Happy Buff Strength = 1.1
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill Experience Gain Factor = 0.6
+Skill Experience Gain Factor = 0.60
 
 ## How much experience to lose in the cooking skill on death.
 # Setting type: Int32

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.exploration.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.exploration.cfg
@@ -59,7 +59,7 @@ Treasure Multiplication Chance = 25
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill Experience Gain Factor = 0.6
+Skill Experience Gain Factor = 0.70
 
 ## How much experience to lose in the exploration skill on death.
 # Setting type: Int32

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.farming.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.farming.cfg
@@ -65,7 +65,7 @@ Random Rotation = Off
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill Experience Gain Factor = 1.25
+Skill Experience Gain Factor = 0.65
 
 ## How much experience to lose in the farming skill on death.
 # Setting type: Int32

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.foraging.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.foraging.cfg
@@ -49,7 +49,7 @@ Multiplier for Respawn Speed = 2
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill Experience Gain Factor = 0.5
+Skill Experience Gain Factor = 0.65
 
 ## How much experience to lose in the foraging skill on death.
 # Setting type: Int32

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.lumberjacking.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.lumberjacking.cfg
@@ -39,7 +39,7 @@ Movement speed modifier in forests at level 100 = 1.5
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill Experience Gain Factor = 0.5
+Skill Experience Gain Factor = 0.60
 
 ## How much experience to lose in the lumberjacking skill on death.
 # Setting type: Int32

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.mining.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.mining.cfg
@@ -46,7 +46,7 @@ Toggle Explosive Mining Hotkey = T + LeftControl
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill Experience Gain Factor = 0.5
+Skill Experience Gain Factor = 0.72
 
 ## How much experience to lose in the mining skill on death.
 # Setting type: Int32

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.packhorse.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.packhorse.cfg
@@ -7,7 +7,7 @@
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill gain factor = 0.5
+Skill gain factor = 0.70
 
 ## The power of the skill, based on the default power.
 # Setting type: Single

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.ranching.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.ranching.cfg
@@ -47,7 +47,7 @@ Pregnancy Level Requirement = 40
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill Experience Gain Factor = 0.6
+Skill Experience Gain Factor = 0.60
 
 ## How much experience to lose in the ranching skill on death.
 # Setting type: Int32

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.tenacity.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.tenacity.cfg
@@ -7,7 +7,7 @@
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Skill gain factor = 0.4
+Skill gain factor = 0.65
 
 ## The power of the skill, based on the default power.
 # Setting type: Single

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/shudnal.Seasons/Default settings/Custom stats.json
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/shudnal.Seasons/Default settings/Custom stats.json
@@ -11,10 +11,10 @@
     "m_staminaRegenMultiplier": 1.0,
     "m_eitrRegenMultiplier": 1.0,
     "m_raiseSkills": {
-      "Jump": 1.2,
-      "Sneak": 1.2,
-      "Run": 1.2,
-      "Swim": 1.2
+      "Jump": 0.80,
+      "Sneak": 0.70,
+      "Run": 1.10,
+      "Swim": 1.50
     },
     "m_skillLevels": {
       "Jump": 15.0,
@@ -45,10 +45,10 @@
     "m_staminaRegenMultiplier": 1.0,
     "m_eitrRegenMultiplier": 1.0,
     "m_raiseSkills": {
-      "Jump": 1.1,
-      "Sneak": 1.1,
-      "Run": 1.1,
-      "Swim": 1.1
+      "Jump": 0.80,
+      "Sneak": 0.70,
+      "Run": 1.10,
+      "Swim": 1.50
     },
     "m_skillLevels": {
       "Jump": 10.0,
@@ -77,9 +77,9 @@
     "m_staminaRegenMultiplier": 1.0,
     "m_eitrRegenMultiplier": 1.1,
     "m_raiseSkills": {
-      "WoodCutting": 1.2,
-      "Fishing": 1.2,
-      "Pickaxes": 1.2
+      "WoodCutting": 0.60,
+      "Fishing": 0.75,
+      "Pickaxes": 0.72
     },
     "m_skillLevels": {
       "WoodCutting": 15.0,
@@ -107,9 +107,9 @@
     "m_staminaRegenMultiplier": 1.1,
     "m_eitrRegenMultiplier": 1.0,
     "m_raiseSkills": {
-      "WoodCutting": 1.1,
-      "Fishing": 1.1,
-      "Pickaxes": 1.1
+      "WoodCutting": 0.60,
+      "Fishing": 0.75,
+      "Pickaxes": 0.72
     },
     "m_skillLevels": {
       "WoodCutting": 10.0,


### PR DESCRIPTION
## Summary
- tune season-based skill multipliers for run, jump, swim, sneak, woodcutting, fishing, and pickaxes
- rebalance experience gain factors for gathering and crafting skills
- calibrate pack horse, tenacity, and building skill growth rates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68990517ead083319a9aab758df58446