### PR TITLE
Reset EpicMMO UI to default position

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.EpicMMOSystemUI.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.EpicMMOSystemUI.cfg
@@ -111,5 +111,5 @@ Force EitrBar = false
 ## Position of the NavBar (x,y) [Not Synced with Server]
 # Setting type: Vector2
 # Default value: {"x":0.0,"y":100.0}
-8.0NavBarPosition = {"x":-2.0,"y":100.0}
+8.0NavBarPosition = {"x":0.0,"y":100.0}
 


### PR DESCRIPTION
## Summary
- Restore EpicMMO nav bar position to default values

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689918a000d48331b80fc20e73564b2f