### PR TITLE
feat: tie ship usage to sailing skill

### DIFF
--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/org.bepinex.plugins.sailing.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/org.bepinex.plugins.sailing.cfg
@@ -50,19 +50,19 @@ Karve Speed Factor = 1.5
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Karve Paddle Requirement = 0
+Karve Paddle Requirement = 10
 
 ## Required sailing skill level to be able to sail a Karve with reduced sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Karve Half Requirement = 0
+Karve Half Requirement = 10
 
 ## Required sailing skill level to be able to sail a Karve with full sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Karve Full Requirement = 0
+Karve Full Requirement = 10
 
 ## Speed factor for Longship at skill level 100.
 # Setting type: Single
@@ -74,19 +74,19 @@ Longship Speed Factor = 1.5
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Longship Paddle Requirement = 0
+Longship Paddle Requirement = 30
 
 ## Required sailing skill level to be able to sail a Longship with reduced sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Longship Half Requirement = 0
+Longship Half Requirement = 30
 
 ## Required sailing skill level to be able to sail a Longship with full sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Longship Full Requirement = 0
+Longship Full Requirement = 30
 
 ## Speed factor for Drakkar at skill level 100.
 # Setting type: Single
@@ -98,19 +98,19 @@ Drakkar Speed Factor = 1.5
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Drakkar Paddle Requirement = 0
+Drakkar Paddle Requirement = 50
 
 ## Required sailing skill level to be able to sail a Drakkar with reduced sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Drakkar Half Requirement = 0
+Drakkar Half Requirement = 50
 
 ## Required sailing skill level to be able to sail a Drakkar with full sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Drakkar Full Requirement = 0
+Drakkar Full Requirement = 50
 
 [3 - Other]
 

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/org.bepinex.plugins.sailing.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/org.bepinex.plugins.sailing.cfg
@@ -50,19 +50,19 @@ Karve Speed Factor = 1.5
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Karve Paddle Requirement = 0
+Karve Paddle Requirement = 10
 
 ## Required sailing skill level to be able to sail a Karve with reduced sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Karve Half Requirement = 0
+Karve Half Requirement = 10
 
 ## Required sailing skill level to be able to sail a Karve with full sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Karve Full Requirement = 0
+Karve Full Requirement = 10
 
 ## Speed factor for Longship at skill level 100.
 # Setting type: Single
@@ -74,19 +74,19 @@ Longship Speed Factor = 1.5
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Longship Paddle Requirement = 0
+Longship Paddle Requirement = 30
 
 ## Required sailing skill level to be able to sail a Longship with reduced sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Longship Half Requirement = 0
+Longship Half Requirement = 30
 
 ## Required sailing skill level to be able to sail a Longship with full sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Longship Full Requirement = 0
+Longship Full Requirement = 30
 
 ## Speed factor for Drakkar at skill level 100.
 # Setting type: Single
@@ -98,19 +98,19 @@ Drakkar Speed Factor = 1.5
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Drakkar Paddle Requirement = 0
+Drakkar Paddle Requirement = 50
 
 ## Required sailing skill level to be able to sail a Drakkar with reduced sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Drakkar Half Requirement = 0
+Drakkar Half Requirement = 50
 
 ## Required sailing skill level to be able to sail a Drakkar with full sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Drakkar Full Requirement = 0
+Drakkar Full Requirement = 50
 
 [3 - Other]
 

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/org.bepinex.plugins.sailing.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/org.bepinex.plugins.sailing.cfg
@@ -50,19 +50,19 @@ Karve Speed Factor = 1.5
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Karve Paddle Requirement = 0
+Karve Paddle Requirement = 10
 
 ## Required sailing skill level to be able to sail a Karve with reduced sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Karve Half Requirement = 0
+Karve Half Requirement = 10
 
 ## Required sailing skill level to be able to sail a Karve with full sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Karve Full Requirement = 0
+Karve Full Requirement = 10
 
 ## Speed factor for Longship at skill level 100.
 # Setting type: Single
@@ -74,19 +74,19 @@ Longship Speed Factor = 1.5
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Longship Paddle Requirement = 0
+Longship Paddle Requirement = 30
 
 ## Required sailing skill level to be able to sail a Longship with reduced sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Longship Half Requirement = 0
+Longship Half Requirement = 30
 
 ## Required sailing skill level to be able to sail a Longship with full sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Longship Full Requirement = 0
+Longship Full Requirement = 30
 
 ## Speed factor for Drakkar at skill level 100.
 # Setting type: Single
@@ -98,19 +98,19 @@ Drakkar Speed Factor = 1.5
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Drakkar Paddle Requirement = 0
+Drakkar Paddle Requirement = 50
 
 ## Required sailing skill level to be able to sail a Drakkar with reduced sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Drakkar Half Requirement = 0
+Drakkar Half Requirement = 50
 
 ## Required sailing skill level to be able to sail a Drakkar with full sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Drakkar Full Requirement = 0
+Drakkar Full Requirement = 50
 
 [3 - Other]
 

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/org.bepinex.plugins.sailing.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/org.bepinex.plugins.sailing.cfg
@@ -50,19 +50,19 @@ Karve Speed Factor = 1.5
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Karve Paddle Requirement = 0
+Karve Paddle Requirement = 10
 
 ## Required sailing skill level to be able to sail a Karve with reduced sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Karve Half Requirement = 0
+Karve Half Requirement = 10
 
 ## Required sailing skill level to be able to sail a Karve with full sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Karve Full Requirement = 0
+Karve Full Requirement = 10
 
 ## Speed factor for Longship at skill level 100.
 # Setting type: Single
@@ -74,19 +74,19 @@ Longship Speed Factor = 1.5
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Longship Paddle Requirement = 0
+Longship Paddle Requirement = 30
 
 ## Required sailing skill level to be able to sail a Longship with reduced sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Longship Half Requirement = 0
+Longship Half Requirement = 30
 
 ## Required sailing skill level to be able to sail a Longship with full sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Longship Full Requirement = 0
+Longship Full Requirement = 30
 
 ## Speed factor for Drakkar at skill level 100.
 # Setting type: Single
@@ -98,19 +98,19 @@ Drakkar Speed Factor = 1.5
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Drakkar Paddle Requirement = 0
+Drakkar Paddle Requirement = 50
 
 ## Required sailing skill level to be able to sail a Drakkar with reduced sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Drakkar Half Requirement = 0
+Drakkar Half Requirement = 50
 
 ## Required sailing skill level to be able to sail a Drakkar with full sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Drakkar Full Requirement = 0
+Drakkar Full Requirement = 50
 
 [3 - Other]
 

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.sailing.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.sailing.cfg
@@ -50,19 +50,19 @@ Karve Speed Factor = 1.5
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Karve Paddle Requirement = 0
+Karve Paddle Requirement = 10
 
 ## Required sailing skill level to be able to sail a Karve with reduced sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Karve Half Requirement = 0
+Karve Half Requirement = 10
 
 ## Required sailing skill level to be able to sail a Karve with full sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Karve Full Requirement = 0
+Karve Full Requirement = 10
 
 ## Speed factor for Longship at skill level 100.
 # Setting type: Single
@@ -74,19 +74,19 @@ Longship Speed Factor = 1.5
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Longship Paddle Requirement = 0
+Longship Paddle Requirement = 30
 
 ## Required sailing skill level to be able to sail a Longship with reduced sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Longship Half Requirement = 0
+Longship Half Requirement = 30
 
 ## Required sailing skill level to be able to sail a Longship with full sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Longship Full Requirement = 0
+Longship Full Requirement = 30
 
 ## Speed factor for Drakkar at skill level 100.
 # Setting type: Single
@@ -98,19 +98,19 @@ Drakkar Speed Factor = 1.5
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Drakkar Paddle Requirement = 0
+Drakkar Paddle Requirement = 50
 
 ## Required sailing skill level to be able to sail a Drakkar with reduced sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Drakkar Half Requirement = 0
+Drakkar Half Requirement = 50
 
 ## Required sailing skill level to be able to sail a Drakkar with full sail.
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Drakkar Full Requirement = 0
+Drakkar Full Requirement = 50
 
 ## Speed factor for Merchant's boat at skill level 100.
 # Setting type: Single


### PR DESCRIPTION
## Summary
- require sailing skill 10/30/50 for Karve, Longship, Drakkar across configs

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899f9506cf8833193a583f7d1475775