### PR TITLE
Adjust swamp spawn settings

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
@@ -107,8 +107,8 @@ PrefabName = MushroomSwamp_MP
 Biomes = Swamp
 Enabled = true
 MaxSpawned = 1
-SpawnInterval = 600
-SpawnChance = 15.00
+SpawnInterval = 900
+SpawnChance = 10.00
 ConditionDistanceToCenterMin = 500
 
 [WorldSpawner.669]
@@ -267,8 +267,8 @@ PrefabName = Leech
 Biomes = Swamp
 Enabled = true
 MaxSpawned = 1
-SpawnInterval = 1200
-SpawnChance = 7.50
+SpawnInterval = 1800
+SpawnChance = 5.00
 RequiredEnvironments = Rain
 SpawnDuringDay = false
 SpawnDuringNight = true


### PR DESCRIPTION
## Summary
- slow down mushroom spawns in the swamp to reduce density
- make Leech Matron spawn less frequently

## Testing
- `python scripts/config_change_tracker.py` (fails: no display name and no $DISPLAY environment variable)

------
https://chatgpt.com/codex/tasks/task_e_689be840dd8c8331bd5734a4be878340