### PR TITLE
Balance Swamp pack spawns and creature lists

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.More_World_Locations_CreatureLists.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.More_World_Locations_CreatureLists.yml
@@ -1,3 +1,4 @@
+---
 # Enhanced Creature Lists for More World Locations
 # Optimized for reduced spawn quantities with increased variety and excitement
 # Aligned with CONTINUE.md material-focused economy and thematic consistency
@@ -194,7 +195,8 @@ WoodTavernCreatures1:
 
 # Black Forest Pack 2 - Enhanced Creature Variety
 # Thematic consistency with Black Forest biome identity
-# Performance optimized with enhanced elite density to compensate for reduced spawn quantities
+# Performance optimized with enhanced elite density
+# to compensate for reduced spawn quantities
 
 BlackforestPack2Creatures1:
   # Common/Forge locations - Diverse mix for early Black Forest progression
@@ -368,11 +370,12 @@ BlackforestPack2GraveCreatures1:
   - Skeleton_Poison
   - Greydwarf_Elite
   - Skeleton_NoArcher
-  - Greydwarf_Shaman 
+  - Greydwarf_Shaman
 
 # Underground Ruins - Black Forest Procedural Dungeon
 # Thematic consistency with dangerous underground Black Forest environment
-# Enhanced elite density to match dungeon danger level and material-focused economy
+# Enhanced elite density to match dungeon danger level
+# and material-focused economy
 
 UndergroundRuinsCreatures1:
   # Underground dungeon - Enhanced elite presence for dangerous environment
@@ -418,8 +421,10 @@ UndergroundRuinsCreatures1:
   - Greydwarf
 
 # Forbidden Catacombs - Swamp Biome Procedural Dungeon
-# Dual-section dungeon with thematic distinction between upper nobles and lower commoners
-# Enhanced elite density to match dangerous swamp dungeon environment and material-focused economy
+# Dual-section dungeon with thematic distinction between upper nobles
+# and lower commoners
+# Enhanced elite density to match dangerous swamp dungeon environment
+# and material-focused economy
 
 CatacombCreatures1:
   # Upper Catacombs - Noble undead section with organized skeletal warriors
@@ -457,7 +462,8 @@ CatacombCreatures1:
 CatacombCreatures2:
   # Lower Catacombs - Rotting commoner section with tortured souls
   # Focus: Suffering spirits and corrupted remains of the forgotten masses
-  # Lore: "Below, the lowborn—left to rot in shadow, their graves marked by stench and sorrow"
+  # Lore: "Below, the lowborn—left to rot in shadow,
+  # their graves marked by stench and sorrow"
   # Elite density ~65% to match lower danger and provide premium materials
   - Skeleton
   - Skeleton_Poison
@@ -502,11 +508,12 @@ CatacombCreatures2:
   - Wraith
   - Skeleton_Poison
   - Wraith
-  - Skeleton_NoArcher 
+  - Skeleton_NoArcher
 
 # Mountains Pack 1 - Enhanced Creature Variety
 # Thematic consistency with Mountains biome identity
-# Performance optimized with enhanced elite density to compensate for reduced spawn quantities
+# Performance optimized with enhanced elite density
+# to compensate for reduced spawn quantities
 
 MountainsCreatures1:
   # Common locations - Diverse mix for early Mountains progression
@@ -629,11 +636,12 @@ MountainsCreatures4:
   - Ulv
   - Hatchling
   - Ulv
-  - Hatchling 
+  - Hatchling
 
 # Plains Pack 1 - Enhanced Creature Variety
 # Thematic consistency with Plains biome identity
-# Performance optimized with enhanced elite density to compensate for reduced spawn quantities
+# Performance optimized with enhanced elite density
+# to compensate for reduced spawn quantities
 
 PlainsCreatures1:
   # Common locations - Diverse mix for early Plains progression
@@ -751,11 +759,12 @@ PlainsCreatures3:
   - GoblinBrute
   - Lox
   - GoblinBrute
-  - Lox 
+  - Lox
 
 # Swamp Pack 1 - Enhanced Creature Variety
 # Thematic consistency with Swamp biome identity
-# Performance optimized with enhanced elite density to compensate for reduced spawn quantities
+# Performance optimized with enhanced elite density
+# to compensate for reduced spawn quantities
 
 SwampCreatures1:
   # Common swamp locations - Diverse mix for early Swamp progression
@@ -776,15 +785,15 @@ SwampCreatures1:
   - Draugr_Elite
   - Wraith
   - Skeleton_NoArcher
-  - Draugr_Elite
+  - Draugr
   - Skeleton_Poison
-  - Wraith
+  - Skeleton
   # Rare spawns for excitement (25% chance)
   - Wraith
   - Draugr_Elite
   - Skeleton_Poison
-  - Wraith
-  - Draugr_Elite
+  - Skeleton
+  - Draugr
 
 SwampCreatures2:
   # Uncommon swamp locations - Higher tier creatures for better rewards
@@ -797,31 +806,31 @@ SwampCreatures2:
   - Draugr_Elite
   - Wraith
   - Skeleton_Poison
-  - Draugr_Elite
-  - Wraith
+  - Draugr
+  - Skeleton
   - Skeleton_NoArcher
   # Elite variants for premium materials (50% chance)
   - Skeleton_Poison
   - Draugr_Elite
   - Wraith
   - Skeleton_NoArcher
-  - Draugr_Elite
+  - Draugr
   - Skeleton_Poison
-  - Wraith
+  - Skeleton
   - Draugr_Elite
   - Skeleton_Poison
   - Wraith
   - Skeleton_NoArcher
-  - Draugr_Elite
+  - Draugr
   # Rare elite spawns for excitement (35% chance)
   - Wraith
   - Draugr_Elite
   - Skeleton_Poison
-  - Wraith
-  - Draugr_Elite
+  - Skeleton
+  - Draugr
   - Skeleton_NoArcher
   - Wraith
-  - Draugr_Elite
+  - Draugr
 
 SwampCreatures3:
   # Elite swamp locations - Maximum challenge and rewards
@@ -835,40 +844,40 @@ SwampCreatures3:
   - Skeleton_NoArcher
   # Elite variants for ultimate materials (75% chance)
   - Skeleton_Poison
-  - Draugr_Elite
-  - Wraith
+  - Draugr
+  - Skeleton
   - Skeleton_NoArcher
   - Draugr_Elite
   - Skeleton_Poison
   - Wraith
-  - Draugr_Elite
+  - Draugr
   - Skeleton_Poison
-  - Wraith
+  - Skeleton
   - Skeleton_NoArcher
   - Draugr_Elite
   - Skeleton_Poison
   - Wraith
-  - Draugr_Elite
+  - Draugr
   - Skeleton_NoArcher
-  - Wraith
+  - Skeleton
   - Draugr_Elite
   - Skeleton_Poison
   - Wraith
   - Skeleton_NoArcher
-  - Draugr_Elite
+  - Draugr
   # Rare elite spawns for maximum excitement (35% chance)
-  - Wraith
+  - Skeleton
   - Draugr_Elite
   - Skeleton_Poison
   - Wraith
-  - Draugr_Elite
+  - Draugr
   - Skeleton_NoArcher
-  - Wraith
+  - Skeleton
   - Draugr_Elite
   - Skeleton_Poison
   - Wraith
   - Skeleton_NoArcher
-  - Draugr_Elite
+  - Draugr
 
 SwampCreatures4:
   # Special swamp locations - Balanced mix for unique encounters
@@ -880,23 +889,23 @@ SwampCreatures4:
   - Draugr_Elite
   - Wraith
   - Skeleton_Poison
-  - Draugr_Elite
-  - Wraith
+  - Draugr
+  - Skeleton
   - Skeleton_NoArcher
   # Elite variants for better materials (50% chance)
   - Skeleton_Poison
   - Draugr_Elite
   - Wraith
   - Skeleton_NoArcher
-  - Draugr_Elite
+  - Draugr
   - Skeleton_Poison
-  - Wraith
+  - Skeleton
   - Draugr_Elite
   - Skeleton_Poison
   - Wraith
   # Rare spawns for excitement (30% chance)
-  - Wraith
-  - Draugr_Elite
+  - Skeleton
+  - Draugr
   - Skeleton_Poison
   - Wraith
   - Draugr_Elite
@@ -992,11 +1001,12 @@ SwampHouseCreatures1:
   - Draugr_Elite
   - Skeleton_Poison
   - Wraith
-  - Skeleton_NoArcher 
+  - Skeleton_NoArcher
 
 # Mistlands Pack 1 - Enhanced Creature Variety
 # Thematic consistency with Mistlands biome identity
-# Performance optimized with enhanced elite density to compensate for reduced spawn quantities
+# Performance optimized with enhanced elite density
+# to compensate for reduced spawn quantities
 
 MistlandsCreatures1:
   # Common mistlands locations - Diverse mix for early Mistlands progression
@@ -1213,11 +1223,12 @@ MistlandsHouseCreatures1:
   - Gjall
   - Seeker
   - SeekerBrute
-  - Tick 
+  - Tick
 
 # Ashlands Pack 1 - Enhanced Creature Variety
 # Thematic consistency with Ashlands biome identity
-# Performance optimized with enhanced elite density to compensate for reduced spawn quantities
+# Performance optimized with enhanced elite density
+# to compensate for reduced spawn quantities
 
 AshlandsCreatures1:
   # Common ashlands locations - Diverse mix for early Ashlands progression
@@ -1248,11 +1259,12 @@ AshlandsCreatures1:
   - Charred_Mage
   - Morgen_NonSleeping
   - Charred_Mage
-  - Morgen_NonSleeping 
+  - Morgen_NonSleeping
 
 # Adventure Map Pack 1 - Enhanced Creature Variety
 # Mixed biome pack with thematic consistency per location type
-# Performance optimized with enhanced elite density to compensate for reduced spawn quantities
+# Performance optimized with enhanced elite density
+# to compensate for reduced spawn quantities
 
 MistCreatures1:
   # Mistlands locations - Diverse mix for Mistlands progression
@@ -1314,4 +1326,4 @@ MountainCreatures1:
   - Ulv
   - Hatchling
   - Ulv
-  - Hatchling 
+  - Hatchling

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.Swamp_Pack_1.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.Swamp_Pack_1.cfg
@@ -6,7 +6,7 @@
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 15
-Spawn Quantity = 11
+Spawn Quantity = 5
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -35,7 +35,7 @@ Name of Loot List = SwampPack1Loot1
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 20
-Spawn Quantity = 13
+Spawn Quantity = 6
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -64,7 +64,7 @@ Name of Loot List = SwampPack1Loot4
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 25
-Spawn Quantity = 16
+Spawn Quantity = 8
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -93,7 +93,7 @@ Name of Loot List = SwampPack1Loot4
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 25
-Spawn Quantity = 16
+Spawn Quantity = 8
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -122,7 +122,7 @@ Name of Loot List = SwampPack1Loot4
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 20
-Spawn Quantity = 13
+Spawn Quantity = 6
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -151,7 +151,7 @@ Name of Loot List = SwampPack1Loot1
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 15
-Spawn Quantity = 11
+Spawn Quantity = 5
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -180,7 +180,7 @@ Name of Loot List = SwampPack1Loot6
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 20
-Spawn Quantity = 13
+Spawn Quantity = 6
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -209,7 +209,7 @@ Name of Loot List = SwampPack1Loot6
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 20
-Spawn Quantity = 13
+Spawn Quantity = 6
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -296,7 +296,7 @@ Name of Loot List = SwampPack1Loot10
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 15
-Spawn Quantity = 11
+Spawn Quantity = 5
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -441,7 +441,7 @@ Name of Loot List = SwampPack1Loot3
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 25
-Spawn Quantity = 16
+Spawn Quantity = 8
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -470,7 +470,7 @@ Name of Loot List = SwampPack1Loot5
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 20
-Spawn Quantity = 13
+Spawn Quantity = 6
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -499,7 +499,7 @@ Name of Loot List = SwampPack1Loot6
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 25
-Spawn Quantity = 16
+Spawn Quantity = 8
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle


### PR DESCRIPTION
## Summary
- Lower Swamp Pack 1 spawn quantities to single digits
- Rebalance Swamp creature lists by replacing excess Wraith/Draugr Elite entries with Skeletons and Draugr
- Add YAML document header and wrap long comments to satisfy yamllint

## Testing
- `yamllint Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.More_World_Locations_CreatureLists.yml`


------
https://chatgpt.com/codex/tasks/task_e_689be84141e08331a0d3b6a7d4a6dc20