### PR TITLE
Tune swamp structure spawners

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.local_spawners.swamp_structures.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.local_spawners.swamp_structures.cfg
@@ -1,0 +1,21 @@
+# Tweaks to swamp structure spawners to avoid stacking pressure.
+# HelWraith swaps and bone piles previously caused permanent red-alert zones.
+# Limiting each structure to a single occupant with long respawn times preserves threat without spam.
+
+# Swamp huts retain a single Wraith with an extended respawn interval.
+[SwampHut3.Wraith]
+RespawnTime=1500
+
+[SwampHut5.Wraith]
+RespawnTime=1500
+
+# Disable additional Draugr spawns in huts to keep only one occupant active.
+[SwampHut4.Draugr]
+Enabled=False
+
+[SwampHut4.Draugr_Ranged]
+Enabled=False
+
+# Wells retain their elite guard but with a long respawn to prevent piling.
+[SwampWell1.Draugr_Elite]
+RespawnTime=1500


### PR DESCRIPTION
## Summary
- cut back swamp hut and well spawner pressure so only one mob resurfaces after a long delay

## Testing
- `python scripts/config_change_tracker.py --help` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_689cf319a8a08331863f568e1d7e4119