### PR TITLE
Adjust swamp chest loot to balance materials

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/EpicLoot/patches/zLootables_SwampChests.json
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/EpicLoot/patches/zLootables_SwampChests.json
@@ -1,0 +1,18 @@
+{
+  "TargetFile": "loottables.json",
+  "Author": "Majestic",
+  "Priority": 901,
+  "RequireAll": true,
+  "Patches": [
+    {
+      "Path": "$.LootTables[?(@.Object == 'TreasureChest_sunkencrypt')].Drops",
+      "Action": "Overwrite",
+      "Value": [ [1, 0], [2, 60], [3, 30], [4, 10] ]
+    },
+    {
+      "Path": "$.LootTables[?(@.Object == 'TreasureChest_swamp')].Drops",
+      "Action": "Overwrite",
+      "Value": [ [1, 0], [2, 60], [3, 30], [4, 10] ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Increase drop counts for Swamp chests to offset reduced mob ticks and maintain materials economy

## Testing
- `python -m json.tool Valheim/profiles/Dogeheim_Player/BepInEx/config/EpicLoot/patches/zLootables_SwampChests.json`


------
https://chatgpt.com/codex/tasks/task_e_689cf3573dac833194312e2a29af7732