### PR TITLE
feat: boost MMO level rewards

### DIFF
--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/WackyMole.EpicMMOSystem.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/WackyMole.EpicMMOSystem.cfg
@@ -30,7 +30,7 @@ PriceResetPoints = 5
 ## Free points per level. Свободных поинтов за один уровень [Synced with Server]
 # Setting type: Int32
 # Default value: 5
-FreePointForLevel = 2
+FreePointForLevel = 4
 
 ## Additional free points start. Дополнительных свободных поинтов [Synced with Server]
 # Setting type: Int32
@@ -85,7 +85,7 @@ LossExp = true
 ## Added bonus point for level. Example(level:points): 5:10,15:20 add all 30 points  [Synced with Server]
 # Setting type: String
 # Default value: 5:5,10:5
-BonusLevelPoints = 5:2,10:2,15:2,20:3,25:2,30:2,35:2,40:3,45:2,50:2,55:2,60:3,65:2,70:2,75:2,80:4,85:5,90:5
+BonusLevelPoints = 5:2,10:2,15:2,20:4,25:2,30:2,35:2,40:4,45:2,50:2,55:2,60:5,65:2,70:2,75:2,80:6,85:5,90:5
 
 ## The range at which people in a group (Group MOD ONLY) get XP, relative to player who killed mob - only works if the killer gets xp. - Default 70f, a large number like 999999999999f, will probably cover map [Synced with Server]
 # Setting type: Single

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/WackyMole.EpicMMOSystem.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/WackyMole.EpicMMOSystem.cfg
@@ -30,7 +30,7 @@ PriceResetPoints = 5
 ## Free points per level. Свободных поинтов за один уровень [Synced with Server]
 # Setting type: Int32
 # Default value: 5
-FreePointForLevel = 2
+FreePointForLevel = 4
 
 ## Additional free points start. Дополнительных свободных поинтов [Synced with Server]
 # Setting type: Int32
@@ -85,7 +85,7 @@ LossExp = true
 ## Added bonus point for level. Example(level:points): 5:10,15:20 add all 30 points  [Synced with Server]
 # Setting type: String
 # Default value: 5:5,10:5
-BonusLevelPoints = 5:2,10:2,15:2,20:3,25:2,30:2,35:2,40:3,45:2,50:2,55:2,60:3,65:2,70:2,75:2,80:4,85:5,90:5
+BonusLevelPoints = 5:2,10:2,15:2,20:4,25:2,30:2,35:2,40:4,45:2,50:2,55:2,60:5,65:2,70:2,75:2,80:6,85:5,90:5
 
 ## The range at which people in a group (Group MOD ONLY) get XP, relative to player who killed mob - only works if the killer gets xp. - Default 70f, a large number like 999999999999f, will probably cover map [Synced with Server]
 # Setting type: Single

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/WackyMole.EpicMMOSystem.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/WackyMole.EpicMMOSystem.cfg
@@ -30,7 +30,7 @@ PriceResetPoints = 5
 ## Free points per level. Свободных поинтов за один уровень [Synced with Server]
 # Setting type: Int32
 # Default value: 5
-FreePointForLevel = 2
+FreePointForLevel = 4
 
 ## Additional free points start. Дополнительных свободных поинтов [Synced with Server]
 # Setting type: Int32
@@ -85,7 +85,7 @@ LossExp = true
 ## Added bonus point for level. Example(level:points): 5:10,15:20 add all 30 points  [Synced with Server]
 # Setting type: String
 # Default value: 5:5,10:5
-BonusLevelPoints = 5:2,10:2,15:2,20:3,25:2,30:2,35:2,40:3,45:2,50:2,55:2,60:3,65:2,70:2,75:2,80:4,85:5,90:5
+BonusLevelPoints = 5:2,10:2,15:2,20:4,25:2,30:2,35:2,40:4,45:2,50:2,55:2,60:5,65:2,70:2,75:2,80:6,85:5,90:5
 
 ## The range at which people in a group (Group MOD ONLY) get XP, relative to player who killed mob - only works if the killer gets xp. - Default 70f, a large number like 999999999999f, will probably cover map [Synced with Server]
 # Setting type: Single

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/WackyMole.EpicMMOSystem.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/WackyMole.EpicMMOSystem.cfg
@@ -30,7 +30,7 @@ PriceResetPoints = 5
 ## Free points per level. Свободных поинтов за один уровень [Synced with Server]
 # Setting type: Int32
 # Default value: 5
-FreePointForLevel = 2
+FreePointForLevel = 4
 
 ## Additional free points start. Дополнительных свободных поинтов [Synced with Server]
 # Setting type: Int32
@@ -85,7 +85,7 @@ LossExp = true
 ## Added bonus point for level. Example(level:points): 5:10,15:20 add all 30 points  [Synced with Server]
 # Setting type: String
 # Default value: 5:5,10:5
-BonusLevelPoints = 5:2,10:2,15:2,20:3,25:2,30:2,35:2,40:3,45:2,50:2,55:2,60:3,65:2,70:2,75:2,80:4,85:5,90:5,95:5,100:5,105:5,110:5,115:5,120:5
+BonusLevelPoints = 5:2,10:2,15:2,20:4,25:2,30:2,35:2,40:4,45:2,50:2,55:2,60:5,65:2,70:2,75:2,80:6,85:5,90:5,95:5,100:6,105:5,110:5,115:5,120:7
 
 ## The range at which people in a group (Group MOD ONLY) get XP, relative to player who killed mob - only works if the killer gets xp. - Default 70f, a large number like 999999999999f, will probably cover map [Synced with Server]
 # Setting type: Single

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.EpicMMOSystem.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.EpicMMOSystem.cfg
@@ -30,7 +30,7 @@ PriceResetPoints = 5
 ## Free points per level. Свободных поинтов за один уровень [Synced with Server]
 # Setting type: Int32
 # Default value: 5
-FreePointForLevel = 2
+FreePointForLevel = 4
 
 ## Additional free points start. Дополнительных свободных поинтов [Synced with Server]
 # Setting type: Int32
@@ -85,7 +85,7 @@ LossExp = true
 ## Added bonus point for level. Example(level:points): 5:10,15:20 add all 30 points  [Synced with Server]
 # Setting type: String
 # Default value: 5:5,10:5
-BonusLevelPoints = 5:2,10:2,15:2,20:3,25:2,30:2,35:2,40:3,45:2,50:2,55:2,60:3,65:2,70:2,75:2,80:4,85:5,90:5,95:5,100:5,105:5,110:5,115:5,120:5
+BonusLevelPoints = 5:2,10:2,15:2,20:4,25:2,30:2,35:2,40:4,45:2,50:2,55:2,60:5,65:2,70:2,75:2,80:6,85:5,90:5,95:5,100:6,105:5,110:5,115:5,120:7
 
 ## The range at which people in a group (Group MOD ONLY) get XP, relative to player who killed mob - only works if the killer gets xp. - Default 70f, a large number like 999999999999f, will probably cover map [Synced with Server]
 # Setting type: Single


### PR DESCRIPTION
## Summary
- grant more free points per level
- add larger BonusLevelPoint bursts at milestone levels

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d2ccded408331bc1358315b2fc54e