### PR TITLE
Tweak blacksmithing progression and crafting balance

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.blacksmithing.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.blacksmithing.cfg
@@ -63,25 +63,25 @@ Skill Level for second Galdr Table Upgrade = 70
 # Setting type: Int32
 # Default value: 70
 # Acceptable value range: From 0 to 100
-Skill Level for Inventory Repair = 70
+Skill Level for Inventory Repair = 50
 
 ## Minimum skill level for an additional upgrade level for armor and weapons. 0 means disabled.
 # Setting type: Int32
 # Default value: 80
 # Acceptable value range: From 0 to 100
-Skill Level for Extra Upgrade Level = 80
+Skill Level for Extra Upgrade Level = 70
 
 ## Factor for durability of armor and weapons at skill level 0.
 # Setting type: Single
 # Default value: 1
 # Acceptable value range: From 0.01 to 5
-Base Durability Factor = 2
+Base Durability Factor = 1.5
 
 ## Factor for durability of armor and weapons at skill level 100.
 # Setting type: Single
 # Default value: 2
 # Acceptable value range: From 1 to 5
-Durability Factor = 4
+Durability Factor = 3
 
 ## Factor for the price of the additional upgrade.
 # Setting type: Single
@@ -93,19 +93,19 @@ Price Factor = 3
 # Setting type: Int32
 # Default value: 75
 # Acceptable value range: From 0 to 200
-First Craft Bonus = 75
+First Craft Bonus = 100
 
 ## After crafting an item this amount of times, crafting it will give reduced blacksmithing experience. Use 0 to disable this.
 # Setting type: Int32
 # Default value: 5
 # Acceptable value range: From 0 to 50
-Experience Reduction Threshold = 5
+Experience Reduction Threshold = 10
 
 ## Factor at which the blacksmithing experience gain is reduced, once too many of the same item have been crafted. Additive, not multiplicative. E.g. reducing the experience gained by 50% every 5 crafts means that you won't get any experience anymore after the 10th craft.
 # Setting type: Single
 # Default value: 0.5
 # Acceptable value range: From 0 to 1
-Experience Reduction Factor = 0.5
+Experience Reduction Factor = 0.25
 
 [3 - Other]
 


### PR DESCRIPTION
## Summary
- ease access to inventory repair and extra upgrade perks
- adjust durability scaling for smoother gear progression
- encourage crafting variety with higher first-craft rewards and softer repetition penalties

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d2d2ab4748331896c1c20369f5fab