### PR TITLE
Adjust Flametal Mace recipe scaling

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackyDatabase-BulkYML/Recipes/Recipe_FlametalMaceHTD.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackyDatabase-BulkYML/Recipes/Recipe_FlametalMaceHTD.yml
@@ -8,9 +8,13 @@ amount: 1
 disabled: false
 disabledUpgrade: false
 requireOnlyOneIngredient: false
-upgrade_reqs: []
+upgrade_reqs:
+- Flametal:10:20:30:40
+- SurtlingCore:10:20:30:40
+- Iron:5:10:15:20
+- LeatherScraps:3:6:9:12
 reqs:
-- Flametal:10:5:True
-- SurtlingCore:15:5:True
-- Iron:10:5:True
-- LeatherScraps:6:0:True
+- Flametal:25:5:True
+- SurtlingCore:25:5:True
+- Iron:20:5:True
+- LeatherScraps:12:0:True


### PR DESCRIPTION
## Summary
- increase base Flametal Mace material requirements
- add upgrade requirement scaling for all materials

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d36b7704883319066ace7b8281f9f