### PR TITLE
Adjust Flametal Great Axe recipe scaling

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackyDatabase-BulkYML/Recipes/Recipe_FlametalGreatAxeHTD.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackyDatabase-BulkYML/Recipes/Recipe_FlametalGreatAxeHTD.yml
@@ -8,9 +8,18 @@ amount: 1
 disabled: false
 disabledUpgrade: false
 requireOnlyOneIngredient: false
-upgrade_reqs: []
+upgrade_reqs:
+- Flametal:20:2
+- Flametal:40:3
+- Flametal:60:4
+- SurtlingCore:15:2
+- SurtlingCore:30:3
+- SurtlingCore:45:4
+- Iron:10:2
+- Iron:20:3
+- Iron:30:4
 reqs:
-- Flametal:15:7:True
-- SurtlingCore:20:7:True
-- Iron:15:7:True
+- Flametal:35:20:True
+- SurtlingCore:30:15:True
+- Iron:25:10:True
 - LeatherScraps:12:0:True


### PR DESCRIPTION
## Summary
- increase Flametal, SurtlingCore, and Iron requirements for FlametalGreatAxeHTD
- add explicit upgrade requirements mirroring scaled amounts

## Testing
- `python - <<'PY'` (YAML validation)

------
https://chatgpt.com/codex/tasks/task_e_689d36b967a88331bcb31503d2b571f7