### PR TITLE
Adjust Plains Mage RtD recipes

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackyDatabase-BulkYML/Recipes/Recipe_Recipe_PlainsMageCape_RtD.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackyDatabase-BulkYML/Recipes/Recipe_Recipe_PlainsMageCape_RtD.yml
@@ -10,7 +10,8 @@ disabledUpgrade: false
 requireOnlyOneIngredient: false
 upgrade_reqs: []
 reqs:
-- BlackMetal:3:2:True
-- LinenThread:5:2:True
-- Tar:5:2:True
+- BlackMetal:20:10:True
+- LinenThread:10:4:True
+- Tar:10:4:True
+- Eitr:10:5:True
 - LoxPelt:3:2:True

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackyDatabase-BulkYML/Recipes/Recipe_Recipe_PlainsMageChest_RtD.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackyDatabase-BulkYML/Recipes/Recipe_Recipe_PlainsMageChest_RtD.yml
@@ -10,7 +10,8 @@ disabledUpgrade: false
 requireOnlyOneIngredient: false
 upgrade_reqs: []
 reqs:
-- BlackMetal:2:2:True
-- LinenThread:25:2:True
-- Tar:5:2:True
+- BlackMetal:20:10:True
+- LinenThread:50:4:True
+- Tar:10:4:True
+- Eitr:10:5:True
 - Needle:2:2:True

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackyDatabase-BulkYML/Recipes/Recipe_Recipe_PlainsMageLegs_RtD.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackyDatabase-BulkYML/Recipes/Recipe_Recipe_PlainsMageLegs_RtD.yml
@@ -11,6 +11,7 @@ requireOnlyOneIngredient: false
 upgrade_reqs: []
 reqs:
 - LoxPelt:10:2:True
-- LinenThread:18:2:True
-- Tar:5:2:True
-- BlackMetal:2:2:True
+- LinenThread:36:4:True
+- Tar:10:4:True
+- Eitr:10:5:True
+- BlackMetal:20:10:True


### PR DESCRIPTION
## Summary
- update Plains Mage cape, chest, and legs recipes to require more BlackMetal
- double Tar and LinenThread costs and add Eitr to each recipe

## Testing
- `yamllint -d '{extends: relaxed, rules: {document-start: disable, truthy: disable, trailing-spaces: disable, indentation: disable}}' Valheim/profiles/Dogeheim_Player/BepInEx/config/wackyDatabase-BulkYML/Recipes/Recipe_Recipe_PlainsMageCape_RtD.yml Valheim/profiles/Dogeheim_Player/BepInEx/config/wackyDatabase-BulkYML/Recipes/Recipe_Recipe_PlainsMageChest_RtD.yml Valheim/profiles/Dogeheim_Player/BepInEx/config/wackyDatabase-BulkYML/Recipes/Recipe_Recipe_PlainsMageLegs_RtD.yml`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d36bcaa7c833183f40e9742af34b6