### PR TITLE
Balance Blackmetal throwing axe recipe

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackyDatabase-BulkYML/Recipes/Recipe_ThrowAxeBlackmetal_TW_Recipe_Forge.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/wackyDatabase-BulkYML/Recipes/Recipe_ThrowAxeBlackmetal_TW_Recipe_Forge.yml
@@ -4,12 +4,12 @@ craftingStation: $piece_forge
 minStationLevel: 4
 maxStationLevelCap: 
 repairStation: 
-amount: 10
+amount: 5
 disabled: false
 disabledUpgrade: false
 requireOnlyOneIngredient: false
 upgrade_reqs: []
 reqs:
-- FineWood:10:0:True
-- LinenThread:1:0:True
-- BlackMetal:3:0:True
+- FineWood:20:0:True
+- LinenThread:5:0:True
+- BlackMetal:20:0:True


### PR DESCRIPTION
## Summary
- raise BlackMetal cost of Blackmetal throwing axe to 20
- increase FineWood to 20 and LinenThread to 5 for the recipe
- reduce crafted amount from 10 to 5

## Testing
- `python - <<'PY'
import yaml,sys
path='Valheim/profiles/Dogeheim_Player/BepInEx/config/wackyDatabase-BulkYML/Recipes/Recipe_ThrowAxeBlackmetal_TW_Recipe_Forge.yml'
with open(path) as f:
    data=yaml.safe_load(f)
print(data)
PY`
- `python -m py_compile $(git ls-files '*.py') && echo 'py_compile success'`


------
https://chatgpt.com/codex/tasks/task_e_689d36be642083319fa84825442e4f17