### PR TITLE
Reduce logging and spawn densities for smoother play

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/BepInEx.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/BepInEx.cfg
@@ -31,7 +31,7 @@ LogChannels = Warn, Error
 ## Enables showing unity log messages in the BepInEx logging system.
 # Setting type: Boolean
 # Default value: true
-UnityLogListening = true
+UnityLogListening = false
 
 ## If enabled, writes Standard Output messages to Unity log
 ## NOTE: By default, Unity does so automatically. Only use this option if no console messages are visible in Unity log
@@ -45,7 +45,7 @@ LogConsoleToUnityLog = false
 ## Enables showing a console for log output.
 # Setting type: Boolean
 # Default value: false
-Enabled = true
+Enabled = false
 
 ## If enabled, will prevent closing the console (either by deleting the close button or in other platform-specific way).
 # Setting type: Boolean

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/custom_raids.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/custom_raids.cfg
@@ -56,13 +56,13 @@ OverrideExisting = true
 ## When the interval has passed, all raids are checked for valid conditions and a random valid one is selected. Chance is then rolled for if it should start.
 # Setting type: Single
 # Default value: 46
-EventCheckInterval = 60
+EventCheckInterval = 90
 
 ## Chance of raid, per check interval. 100 is 100%.
 ## Note: Not used if UseIndividualRaidChecks is enabled, each raid will have their own chance in that case.
 # Setting type: Single
 # Default value: 20
-EventTriggerChance = 40
+EventTriggerChance = 25
 
 [General]
 

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
@@ -17,11 +17,11 @@ PrefabName = Greydwarf
 Biomes = BlackForest
 Enabled = true
 MaxSpawned = 3
-SpawnInterval = 300
-SpawnChance = 12
+SpawnInterval = 600        # was 300 → slower spawn checks
+SpawnChance = 6            # was 12 → lower global density
 SpawnDistance = 70
 GroupSizeMin = 1
-GroupSizeMax = 3
+GroupSizeMax = 2           # was 3 → smaller packs
 GroupRadius = 10
 GroundOffset = 0.5
 SpawnDuringDay = true
@@ -87,8 +87,8 @@ PrefabName = MushroomMeadows_MP
 Biomes = Meadows
 Enabled = true
 MaxSpawned = 1
-SpawnInterval = 900
-SpawnChance = 18.00
+SpawnInterval = 1200       # was 900 → fewer spawn attempts
+SpawnChance = 10.00        # was 18.00 → lower global density
 ConditionDistanceToCenterMin = 500
 
 [WorldSpawner.667]
@@ -97,8 +97,8 @@ PrefabName = MushroomForest_MP
 Biomes = BlackForest
 Enabled = true
 MaxSpawned = 1
-SpawnInterval = 600
-SpawnChance = 15.00
+SpawnInterval = 900        # was 600 → fewer spawn attempts
+SpawnChance = 8.00         # was 15.00 → lower global density
 ConditionDistanceToCenterMin = 500
 
 [WorldSpawner.668]
@@ -107,8 +107,8 @@ PrefabName = MushroomSwamp_MP
 Biomes = Swamp
 Enabled = true
 MaxSpawned = 1
-SpawnInterval = 900
-SpawnChance = 10.00
+SpawnInterval = 1200       # was 900 → fewer spawn attempts
+SpawnChance = 6.00         # was 10.00 → lower global density
 ConditionDistanceToCenterMin = 500
 
 [WorldSpawner.669]
@@ -117,8 +117,8 @@ PrefabName = MushroomMountain_MP
 Biomes = Mountain
 Enabled = true
 MaxSpawned = 2
-SpawnInterval = 750
-SpawnChance = 15.00
+SpawnInterval = 1050       # was 750 → fewer spawn attempts
+SpawnChance = 8.00         # was 15.00 → lower global density
 ConditionDistanceToCenterMin = 500
 
 [WorldSpawner.670]
@@ -127,8 +127,8 @@ PrefabName = MushroomPlains_MP
 Biomes = Plains
 Enabled = true
 MaxSpawned = 1
-SpawnInterval = 750
-SpawnChance = 15.00
+SpawnInterval = 1050       # was 750 → fewer spawn attempts
+SpawnChance = 8.00         # was 15.00 → lower global density
 ConditionDistanceToCenterMin = 500
 
 [WorldSpawner.671]
@@ -137,8 +137,8 @@ PrefabName = MushroomMistlands_MP
 Biomes = Mistlands
 Enabled = true
 MaxSpawned = 2
-SpawnInterval = 900
-SpawnChance = 15.00
+SpawnInterval = 1200       # was 900 → fewer spawn attempts
+SpawnChance = 8.00         # was 15.00 → lower global density
 ConditionDistanceToCenterMin = 500
 
 [WorldSpawner.672]
@@ -147,8 +147,8 @@ PrefabName = MushroomAshLands_MP
 Biomes = AshLands
 Enabled = true
 MaxSpawned = 1
-SpawnInterval = 600
-SpawnChance = 18.00
+SpawnInterval = 900        # was 600 → fewer spawn attempts
+SpawnChance = 10.00        # was 18.00 → lower global density
 ConditionDistanceToCenterMin = 500
 
 [WorldSpawner.673]


### PR DESCRIPTION
## Summary
- Disable runtime console and Unity log capture
- Slow greydwarf and mushroom spawns to cut simultaneous AI
- Space out raid checks and lower trigger chance

## Testing
- `python scripts/validate_yaml_prefabs.py`
- `python scripts/config_change_tracker.py --help` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_689d38dcf834833184fc0b54c36f2207