### PR TITLE
Reduce swamp spawn frequency by 30%

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.local_spawners_advanced.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.local_spawners_advanced.cfg
@@ -13,10 +13,10 @@
 
 # Swamp huts retain a single Wraith with an extended respawn interval.
 [SwampHut3.Wraith]
-RespawnTime=1500
+RespawnTime=1950       # 30% longer respawn
 
 [SwampHut5.Wraith]
-RespawnTime=1500
+RespawnTime=1950       # 30% longer respawn
 
 # Disable additional Draugr spawns in huts to keep only one occupant active.
 [SwampHut4.Draugr]
@@ -27,4 +27,4 @@ Enabled=False
 
 # Wells retain their elite guard but with a long respawn to prevent piling.
 [SwampWell1.Draugr_Elite]
-RespawnTime=1500
+RespawnTime=1950       # 30% longer respawn

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
@@ -108,7 +108,7 @@ Biomes = Swamp
 Enabled = true
 MaxSpawned = 1
 SpawnInterval = 1200       # was 900 → fewer spawn attempts
-SpawnChance = 6.00         # was 10.00 → lower global density
+SpawnChance = 4.20         # was 10.00 → lower global density (30% reduction)
 ConditionDistanceToCenterMin = 500
 
 [WorldSpawner.669]
@@ -268,7 +268,7 @@ Biomes = Swamp
 Enabled = true
 MaxSpawned = 1
 SpawnInterval = 1800
-SpawnChance = 5.00
+SpawnChance = 3.50         # 30% reduction
 RequiredEnvironments = Rain
 SpawnDuringDay = false
 SpawnDuringNight = true


### PR DESCRIPTION
## Summary
- lower Mushroom Swamp spawn chance to 4.20
- drop Leech Matron spawn chance to 3.50
- slow Wraith and Draugr Elite respawns in swamp structures

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689d4a39cb008331a06c082ec4da9f64