### PR TITLE
Increase Spawn That global spawn rate

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.cfg
@@ -86,6 +86,11 @@ ClearAllExisting = false
 # Default value: false
 AlwaysAppend = false
 
+## Global spawn rate multiplier.
+# Setting type: Single
+# Default value: 0.7
+WorldSpawnRate = 1.3
+
 ## Writes world spawner templates to a file, before applying custom changes.
 # Setting type: Boolean
 # Default value: false


### PR DESCRIPTION
## Summary
- raise Spawn That's global spawn rate multiplier from 0.7 to 1.3

## Testing
- `rg -n "WorldSpawnRate" Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.cfg`


------
https://chatgpt.com/codex/tasks/task_e_689d4f8d02388331a98491904426112d