### PR TITLE
Increase enchanted component drop weights

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/_RelicHeimFiles/Drop,Spawn_That/drop_that.drop_table.EpicLootChest.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/_RelicHeimFiles/Drop,Spawn_That/drop_that.drop_table.EpicLootChest.cfg
@@ -15,28 +15,28 @@ DisableResourceModifierScaling=True
 
 [Enchanted_Chest.2]
 PrefabName=EssenceRare
-SetTemplateWeight=0.95
+SetTemplateWeight=1.05
 SetAmountMin=2
 SetAmountMax=2
 DisableResourceModifierScaling=True
 
 [Enchanted_Chest.3]
 PrefabName=RunestoneRare
-SetTemplateWeight=1
+SetTemplateWeight=1.1
 SetAmountMin=2
 SetAmountMax=2
 DisableResourceModifierScaling=True
 
 [Enchanted_Chest.4]
 PrefabName=ShardRare
-SetTemplateWeight=0.95
+SetTemplateWeight=1.05
 SetAmountMin=2
 SetAmountMax=2
 DisableResourceModifierScaling=True
 
 [Enchanted_Chest.5]
 PrefabName=DustRare
-SetTemplateWeight=1
+SetTemplateWeight=1.1
 SetAmountMin=2
 SetAmountMax=4
 DisableResourceModifierScaling=True
@@ -45,28 +45,28 @@ DisableResourceModifierScaling=True
 
 [Enchanted_Chest.6]
 PrefabName=EssenceEpic
-SetTemplateWeight=0.8
+SetTemplateWeight=0.88
 SetAmountMin=1
 SetAmountMax=2
 DisableResourceModifierScaling=True
 
 [Enchanted_Chest.7]
 PrefabName=RunestoneEpic
-SetTemplateWeight=0.9
+SetTemplateWeight=0.99
 SetAmountMin=1
 SetAmountMax=2
 DisableResourceModifierScaling=True
 
 [Enchanted_Chest.8]
 PrefabName=ShardEpic
-SetTemplateWeight=0.8
+SetTemplateWeight=0.88
 SetAmountMin=1
 SetAmountMax=2
 DisableResourceModifierScaling=True
 
 [Enchanted_Chest.9]
 PrefabName=DustEpic
-SetTemplateWeight=0.9
+SetTemplateWeight=0.99
 SetAmountMin=2
 SetAmountMax=3
 DisableResourceModifierScaling=True
@@ -75,28 +75,28 @@ DisableResourceModifierScaling=True
 
 [Enchanted_Chest.10]
 PrefabName=EssenceLegendary
-SetTemplateWeight=0.2
+SetTemplateWeight=0.22
 SetAmountMin=1
 SetAmountMax=2
 DisableResourceModifierScaling=True
 
 [Enchanted_Chest.11]
 PrefabName=RunestoneLegendary
-SetTemplateWeight=0.6
+SetTemplateWeight=0.66
 SetAmountMin=1
 SetAmountMax=2
 DisableResourceModifierScaling=True
 
 [Enchanted_Chest.12]
 PrefabName=ShardLegendary
-SetTemplateWeight=0.2
+SetTemplateWeight=0.22
 SetAmountMin=1
 SetAmountMax=2
 DisableResourceModifierScaling=True
 
 [Enchanted_Chest.13]
 PrefabName=DustLegendary
-SetTemplateWeight=0.4
+SetTemplateWeight=0.44
 SetAmountMin=1
 SetAmountMax=2
 DisableResourceModifierScaling=True
@@ -105,35 +105,35 @@ DisableResourceModifierScaling=True
 
 [Enchanted_Chest.14]
 PrefabName=EssenceMythic
-SetTemplateWeight=0.1
+SetTemplateWeight=0.11
 SetAmountMin=1
 SetAmountMax=2
 DisableResourceModifierScaling=True
 
 [Enchanted_Chest.15]
 PrefabName=RunestoneMythic
-SetTemplateWeight=0.1
+SetTemplateWeight=0.11
 SetAmountMin=1
 SetAmountMax=2
 DisableResourceModifierScaling=True
 
 [Enchanted_Chest.16]
 PrefabName=ShardMythic
-SetTemplateWeight=0.1
+SetTemplateWeight=0.11
 SetAmountMin=1
 SetAmountMax=2
 DisableResourceModifierScaling=True
 
 [Enchanted_Chest.17]
 PrefabName=DustMythic
-SetTemplateWeight=0.1
+SetTemplateWeight=0.11
 SetAmountMin=1
 SetAmountMax=2
 DisableResourceModifierScaling=True
 
 [Enchanted_Chest.18]
 PrefabName=EnchantedKey
-SetTemplateWeight=0.05
+SetTemplateWeight=0.055
 SetAmountMin=1
 SetAmountMax=2
 DisableResourceModifierScaling=True


### PR DESCRIPTION
## Summary
- Boost enchanted component drop rates in Epic Loot chests by raising SetTemplateWeight values for Essence, Runestone, Shard, Dust, and EnchantedKey entries.
- Keep coin rewards unchanged to maintain rarity balance.

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python scripts/validate_yaml_prefabs.py` *(reports 22 invalid prefabs)*

------
https://chatgpt.com/codex/tasks/task_e_689e457f63848331981e52ead9a38263