### PR TITLE
Reduce Meadows Pack 2 spawn rates

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.Meadows_Pack_2.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.Meadows_Pack_2.cfg
@@ -6,7 +6,7 @@
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 10
-Spawn Quantity = 5
+Spawn Quantity = 2
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -35,7 +35,7 @@ Name of Loot List = MeadowsPack2Loot1
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 10
-Spawn Quantity = 5
+Spawn Quantity = 1
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -64,7 +64,7 @@ Name of Loot List = MeadowsPack2Loot2
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 10
-Spawn Quantity = 5
+Spawn Quantity = 2
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -93,7 +93,7 @@ Name of Loot List = MeadowsPack2Loot7
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 10
-Spawn Quantity = 5
+Spawn Quantity = 2
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -122,7 +122,7 @@ Name of Loot List = MeadowsPack2Loot6
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 10
-Spawn Quantity = 5
+Spawn Quantity = 1
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -151,7 +151,7 @@ Name of Loot List = MeadowsPack2Loot5
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 10
-Spawn Quantity = 5
+Spawn Quantity = 1
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -180,7 +180,7 @@ Name of Loot List = MeadowsPack2Loot8
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 10
-Spawn Quantity = 5
+Spawn Quantity = 3
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -209,7 +209,7 @@ Name of Loot List = MeadowsPack2Loot1
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 5
-Spawn Quantity = 3
+Spawn Quantity = 2
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -238,7 +238,7 @@ Name of Loot List = MeadowsPack2Loot2
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 20
-Spawn Quantity = 10
+Spawn Quantity = 4
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -267,7 +267,7 @@ Name of Loot List = MeadowsPack2Loot3
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 5
-Spawn Quantity = 3
+Spawn Quantity = 2
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -296,7 +296,7 @@ Name of Loot List = MeadowsPack2Loot4
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 10
-Spawn Quantity = 5
+Spawn Quantity = 3
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -325,7 +325,7 @@ Name of Loot List = MeadowsPack2Loot4
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 15
-Spawn Quantity = 8
+Spawn Quantity = 4
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -354,7 +354,7 @@ Name of Loot List = MeadowsPack2Loot5
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 15
-Spawn Quantity = 8
+Spawn Quantity = 3
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle
@@ -383,7 +383,7 @@ Name of Loot List = MeadowsPack2Loot3
 ## Amount of this location the game will attempt to place during world generation [Synced with Server]
 # Setting type: Int32
 # Default value: 20
-Spawn Quantity = 10
+Spawn Quantity = 4
 
 ## When Off, location will spawn default creatures. When On, location will select creatures from the list in the warpalicious.More_World_Locations_CreatureLists.yml file in the BepInEx config folder [Synced with Server]
 # Setting type: Toggle


### PR DESCRIPTION
## Summary
- Lowered spawn quantities for all Meadows Pack 2 locations to randomized values between 1 and 4
- Verified referenced creature and loot lists exist for balanced world spawns

## Testing
- `rg 'Spawn Quantity' -n Valheim/profiles/Dogeheim_Player/BepInEx/config/warpalicious.Meadows_Pack_2.cfg`
- World generation simulation not run (environment lacks Valheim runtime)

------
https://chatgpt.com/codex/tasks/task_e_689e46a90bdc83318e457091610d6ab4