### PR TITLE
Remove TempestNeck creature config entry

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/CreatureConfig_Creatures.yml
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/CreatureConfig_Creatures.yml
@@ -10,17 +10,6 @@ Neck:
 Boar:
   health: 3
   health per star: 1
-TempestNeck:
-  health: 200
-  health per star: 100
-  damage: 40
-  damage per star: 20
-  effect:
-    Quick: 10
-    Aggressive: 10
-    Regenerating: 5
-  infusion:
-    Lightning: 100
 #BlackForest
 Greydwarf:
   health: 1.25


### PR DESCRIPTION
## Summary
- remove TempestNeck entry from creature configuration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e46c2d2e483318fc6325af606afc9