### PR TITLE
Align mushroom POI spawn rates across biomes

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.world_spawners_advanced.cfg
@@ -86,9 +86,9 @@ Name = Mushroom Meadows
 PrefabName = MushroomMeadows_MP
 Biomes = Meadows
 Enabled = true
-MaxSpawned = 1
-SpawnInterval = 1500       # was 900 → fewer spawn attempts
-SpawnChance = 7.00         # was 18.00 → lower global density
+MaxSpawned = 1            # aligned for sparse mushrooms
+SpawnInterval = 1500       # aligned across biomes for consistent POI density
+SpawnChance = 4.50         # aligned for sparse mushroom encounters
 ConditionDistanceToCenterMin = 500
 
 [WorldSpawner.667]
@@ -96,9 +96,9 @@ Name = Mushroom Forest
 PrefabName = MushroomForest_MP
 Biomes = BlackForest
 Enabled = true
-MaxSpawned = 1
-SpawnInterval = 1200       # was 600 → fewer spawn attempts
-SpawnChance = 5.60         # was 15.00 → lower global density
+MaxSpawned = 1            # aligned for sparse mushrooms
+SpawnInterval = 1500       # aligned across biomes for consistent POI density
+SpawnChance = 4.50         # aligned for sparse mushroom encounters
 ConditionDistanceToCenterMin = 500
 
 [WorldSpawner.668]
@@ -106,9 +106,9 @@ Name = Mushroom Swamp
 PrefabName = MushroomSwamp_MP
 Biomes = Swamp
 Enabled = true
-MaxSpawned = 1
-SpawnInterval = 1500       # was 900 → fewer spawn attempts
-SpawnChance = 3.00         # was 10.00 → lower global density
+MaxSpawned = 1            # aligned for sparse mushrooms
+SpawnInterval = 1500       # aligned across biomes for consistent POI density
+SpawnChance = 4.50         # aligned for sparse mushroom encounters
 ConditionDistanceToCenterMin = 500
 
 [WorldSpawner.669]
@@ -116,9 +116,9 @@ Name = Mushroom Mountain
 PrefabName = MushroomMountain_MP
 Biomes = Mountain
 Enabled = true
-MaxSpawned = 2
-SpawnInterval = 1350       # was 750 → fewer spawn attempts
-SpawnChance = 5.60         # was 15.00 → lower global density
+MaxSpawned = 1            # aligned for sparse mushrooms
+SpawnInterval = 1500       # aligned across biomes for consistent POI density
+SpawnChance = 4.50         # aligned for sparse mushroom encounters
 ConditionDistanceToCenterMin = 500
 
 [WorldSpawner.670]
@@ -126,9 +126,9 @@ Name = Mushroom Plains
 PrefabName = MushroomPlains_MP
 Biomes = Plains
 Enabled = true
-MaxSpawned = 1
-SpawnInterval = 1350       # was 750 → fewer spawn attempts
-SpawnChance = 5.60         # was 15.00 → lower global density
+MaxSpawned = 1            # aligned for sparse mushrooms
+SpawnInterval = 1500       # aligned across biomes for consistent POI density
+SpawnChance = 4.50         # aligned for sparse mushroom encounters
 ConditionDistanceToCenterMin = 500
 
 [WorldSpawner.671]
@@ -136,9 +136,9 @@ Name = Mushroom Mistlands
 PrefabName = MushroomMistlands_MP
 Biomes = Mistlands
 Enabled = true
-MaxSpawned = 2
-SpawnInterval = 1500       # was 900 → fewer spawn attempts
-SpawnChance = 5.60         # was 15.00 → lower global density
+MaxSpawned = 1            # aligned for sparse mushrooms
+SpawnInterval = 1500       # aligned across biomes for consistent POI density
+SpawnChance = 4.50         # aligned for sparse mushroom encounters
 ConditionDistanceToCenterMin = 500
 
 [WorldSpawner.672]
@@ -146,9 +146,9 @@ Name = Mushroom Ashlands
 PrefabName = MushroomAshLands_MP
 Biomes = AshLands
 Enabled = true
-MaxSpawned = 1
-SpawnInterval = 1200       # was 600 → fewer spawn attempts
-SpawnChance = 7.00         # was 18.00 → lower global density
+MaxSpawned = 1            # aligned for sparse mushrooms
+SpawnInterval = 1500       # aligned across biomes for consistent POI density
+SpawnChance = 4.50         # aligned for sparse mushroom encounters
 ConditionDistanceToCenterMin = 500
 
 [WorldSpawner.673]
@@ -156,9 +156,9 @@ ConditionDistanceToCenterMin = 500
 PrefabName = MushroomDeepNorth_MP
 Biomes = DeepNorth
 Enabled = true
-MaxSpawned = 2
-SpawnInterval = 1050       # was 600 → fewer spawn attempts
-SpawnChance = 12.60        # was 22.50 → lower global density
+MaxSpawned = 1            # aligned for sparse mushrooms
+SpawnInterval = 1500       # aligned across biomes for consistent POI density
+SpawnChance = 4.50         # aligned for sparse mushroom encounters
 ConditionDistanceToCenterMin = 2500  # was 500 → deeper exploration
 
 [WorldSpawner.674]


### PR DESCRIPTION
## Summary
- Standardize spawn rates for mushroom world spawners across all biomes
- Ensure sparse mushroom encounters with unified low spawn chance and interval

## Testing
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_689e47ae3c6483319535b14b0a59aca9