### PR TITLE
Reduce global monster spawn rate by 30%

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/spawn_that.cfg
@@ -89,7 +89,7 @@ AlwaysAppend = false
 ## Global spawn rate multiplier.
 # Setting type: Single
 # Default value: 0.7
-WorldSpawnRate = 1.3
+WorldSpawnRate = 0.7
 
 ## Writes world spawner templates to a file, before applying custom changes.
 # Setting type: Boolean


### PR DESCRIPTION
## Summary
- Lower global spawn multiplier from 1.3 to 0.7 in Spawn That config

## Testing
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_689e4bf63c0483319ed0a33780c436d1