### PR TITLE
Reduce skill loss on death

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/Therzie.Warfare.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/Therzie.Warfare.cfg
@@ -6989,7 +6989,7 @@ Skill effect factor = 1.3
 # Setting type: Int32
 # Default value: 5
 # Acceptable value range: From 0 to 100
-Skill loss = 5
+Skill loss = 3
 
 [skill_99738506]
 
@@ -7009,7 +7009,7 @@ Skill effect factor = 1.3
 # Setting type: Int32
 # Default value: 5
 # Acceptable value range: From 0 to 100
-Skill loss = 5
+Skill loss = 3
 
 [Skullcrusher]
 

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.EpicMMOSystem.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.EpicMMOSystem.cfg
@@ -70,12 +70,12 @@ GroupExp = 0.7
 ## Minimum Loss Exp if player death, default 5% loss [Synced with Server]
 # Setting type: Single
 # Default value: 0.05
-MinLossExp = 0.05
+MinLossExp = 0.03
 
 ## Maximum Loss Exp if player death, default 25% loss [Synced with Server]
 # Setting type: Single
 # Default value: 0.25
-MaxLossExp = 0.15
+MaxLossExp = 0.10
 
 ## Enabled exp loss [Synced with Server]
 # Setting type: Boolean

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.blacksmithing.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.blacksmithing.cfg
@@ -119,5 +119,5 @@ Skill Experience Gain Factor = 0.7
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Skill Experience Loss = 1
+Skill Experience Loss = 0
 

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.farming.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.farming.cfg
@@ -73,7 +73,7 @@ Skill Experience Gain Factor = 0.57
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Skill Experience Loss = 2
+Skill Experience Loss = 1
 
 ## Shortcut to press to toggle between the single plant mode and the mass plant mode. Please note that you have to stand still, to toggle this.
 # Setting type: KeyboardShortcut

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.foraging.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.foraging.cfg
@@ -55,5 +55,5 @@ Skill Experience Gain Factor = 0.60
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Skill Experience Loss = 1
+Skill Experience Loss = 0
 

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.lumberjacking.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.lumberjacking.cfg
@@ -45,5 +45,5 @@ Skill Experience Gain Factor = 0.6
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Skill Experience Loss = 1
+Skill Experience Loss = 0
 

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.mining.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.mining.cfg
@@ -52,5 +52,5 @@ Skill Experience Gain Factor = 0.72
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Skill Experience Loss = 1
+Skill Experience Loss = 0
 

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.packhorse.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.packhorse.cfg
@@ -19,5 +19,5 @@ Skill effect factor = 1
 # Setting type: Int32
 # Default value: 5
 # Acceptable value range: From 0 to 100
-Skill loss = 5
+Skill loss = 3
 

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.sailing.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.sailing.cfg
@@ -472,7 +472,7 @@ Skill Experience Gain Factor = 0.4
 # Setting type: Int32
 # Default value: 0
 # Acceptable value range: From 0 to 100
-Skill Experience Loss = 1
+Skill Experience Loss = 0
 
 ## If on, players can press a hotkey, to give their ship a nudge, if it is stuck.
 # Setting type: Toggle

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.tenacity.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.tenacity.cfg
@@ -19,5 +19,5 @@ Skill effect factor = 0.7
 # Setting type: Int32
 # Default value: 5
 # Acceptable value range: From 0 to 100
-Skill loss = 10
+Skill loss = 6
 


### PR DESCRIPTION
## Summary
- lower MMO experience loss on death to 3-10%
- reduce or remove skill XP loss for profession and combat mods

## Testing
- `python -m py_compile scripts/*.py`
- `python scripts/config_change_tracker.py --help` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_689e9bd3f004833181c4c063f9d49c65