### PR TITLE
Adjust EpicMMO experience rates and death penalties

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.EpicMMOSystem.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.EpicMMOSystem.cfg
@@ -60,22 +60,22 @@ ExpForLvlMonster = 0.25
 ## Experience multiplier. Множитель опыта [Synced with Server]
 # Setting type: Single
 # Default value: 1
-RateExp = 1
+RateExp = 1.15
 
 ## Experience multiplier that the other players in the group get. Множитель опыта который получают остальные игроки в группе [Synced with Server]
 # Setting type: Single
 # Default value: 0.7
-GroupExp = 0.7
+GroupExp = 0.90
 
 ## Minimum Loss Exp if player death, default 5% loss [Synced with Server]
 # Setting type: Single
 # Default value: 0.05
-MinLossExp = 0.03
+MinLossExp = 0.01
 
 ## Maximum Loss Exp if player death, default 25% loss [Synced with Server]
 # Setting type: Single
 # Default value: 0.25
-MaxLossExp = 0.10
+MaxLossExp = 0.04
 
 ## Enabled exp loss [Synced with Server]
 # Setting type: Boolean


### PR DESCRIPTION
## Summary
- Increase global experience rate to 1.15 while keeping the 1.048 exponent
- Boost group experience share to 0.90
- Reduce death experience loss to 1-4%

## Testing
- ⚠️ `python scripts/config_change_tracker.py --help` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_689f3ef52020833187ff81ed87ae380b