### PR TITLE
Disable piece building XP in EpicMMO configs

### DIFF
--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/WackyMole.EpicMMOSystem.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/WackyMole.EpicMMOSystem.cfg
@@ -507,7 +507,7 @@ Use Regular Fermentor = true
 ## Disables Piece XP. You only get xp for once per building, then you have to change to another piece. It still could be abused. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-Disable Piece XP = false
+Disable Piece XP = true
 
 ## Disables XP for tames. [Synced with Server]
 # Setting type: Boolean

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.EpicMMOSystem.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.EpicMMOSystem.cfg
@@ -507,7 +507,7 @@ Use Regular Fermentor = true
 ## Disables Piece XP. You only get xp for once per building, then you have to change to another piece. It still could be abused. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-Disable Piece XP = false
+Disable Piece XP = true
 
 ## Disables XP for tames. [Synced with Server]
 # Setting type: Boolean


### PR DESCRIPTION
## Summary
- disable piece XP in `WackyMole.EpicMMOSystem` configs to prevent repeated building XP gains

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f420b529c8331aada58677450264c