### PR TITLE
Enable pickup XP and fish XP disabling in configs

### DIFF
--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/WackyMole.EpicMMOSystem.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/WackyMole.EpicMMOSystem.cfg
@@ -517,7 +517,7 @@ Disable Tame XP = false
 ## Disable Fish pickup XP, you still get xp for catching fish. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-Disable Fish Pickup XP = false
+Disable Fish Pickup XP = true
 
 ## Disable XP for mining. [Synced with Server]
 # Setting type: Boolean
@@ -527,7 +527,7 @@ Disable Mining XP = false
 ## Disable XP for pickables. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-Disable Pickup XP = false
+Disable Pickup XP = true
 
 ## Disable XP for Chopping Trees. [Synced with Server]
 # Setting type: Boolean

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.EpicMMOSystem.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.EpicMMOSystem.cfg
@@ -517,7 +517,7 @@ Disable Tame XP = false
 ## Disable Fish pickup XP, you still get xp for catching fish. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-Disable Fish Pickup XP = false
+Disable Fish Pickup XP = true
 
 ## Disable XP for mining. [Synced with Server]
 # Setting type: Boolean
@@ -527,7 +527,7 @@ Disable Mining XP = false
 ## Disable XP for pickables. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-Disable Pickup XP = false
+Disable Pickup XP = true
 
 ## Disable XP for Chopping Trees. [Synced with Server]
 # Setting type: Boolean


### PR DESCRIPTION
## Summary
- Enable disabling pickup and fish pickup XP in EpicMMOSystem configs

## Testing
- `python -m py_compile scripts/config_change_tracker.py scripts/item_skill_tracker.py scripts/normalize_skill_yaml.py scripts/validate_yaml_prefabs.py`


------
https://chatgpt.com/codex/tasks/task_e_689f420de1ec8331b7f3b5d044cb52f5