### PR TITLE
Disable destructables XP

### DIFF
--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/WackyMole.EpicMMOSystem.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/WackyMole.EpicMMOSystem.cfg
@@ -537,7 +537,7 @@ Disable Tree XP = false
 ## Disable XP Destructables. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-Disable Destructables XP = false
+Disable Destructables XP = true
 
 ## Gives a Warning log for various objects names. Don't forgot that (Clone) is added to everything in the jsons. [Not Synced with Server]
 # Setting type: Boolean

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.EpicMMOSystem.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.EpicMMOSystem.cfg
@@ -537,7 +537,7 @@ Disable Tree XP = false
 ## Disable XP Destructables. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-Disable Destructables XP = false
+Disable Destructables XP = true
 
 ## Gives a Warning log for various objects names. Don't forgot that (Clone) is added to everything in the jsons. [Not Synced with Server]
 # Setting type: Boolean


### PR DESCRIPTION
## Summary
- disable destructables XP in JewelHeim cache MMO config
- disable destructables XP in player profile MMO config

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f4210347c833191ce3b0b11a42fc4