### PR TITLE
Disable tame XP to stop AFK farming

### DIFF
--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/WackyMole.EpicMMOSystem.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/WackyMole.EpicMMOSystem.cfg
@@ -512,7 +512,7 @@ Disable Piece XP = false
 ## Disables XP for tames. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-Disable Tame XP = false
+Disable Tame XP = true
 
 ## Disable Fish pickup XP, you still get xp for catching fish. [Synced with Server]
 # Setting type: Boolean

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.EpicMMOSystem.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.EpicMMOSystem.cfg
@@ -512,7 +512,7 @@ Disable Piece XP = false
 ## Disables XP for tames. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-Disable Tame XP = false
+Disable Tame XP = true
 
 ## Disable Fish pickup XP, you still get xp for catching fish. [Synced with Server]
 # Setting type: Boolean


### PR DESCRIPTION
## Summary
- Prevent AFK tame farming by enabling Disable Tame XP in player profile config
- Mirror Disable Tame XP setting in bundled 5.4.9 cache config

## Testing
- `python scripts/config_change_tracker.py --help` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_689f4218883883319b52b53bec836a1f