### PR TITLE
Tune bone and draugr pile spawns

### DIFF
--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/_RelicHeimFiles/Drop,Spawn_That/spawn_that.spawnarea_spawners.PilesNests.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/_RelicHeimFiles/Drop,Spawn_That/spawn_that.spawnarea_spawners.PilesNests.cfg
@@ -44,11 +44,11 @@ SpawnWeight=0.2
 IdentifyByName=BonePileSpawner
 IdentifyByBiome=BlackForest
 LevelUpChance=15
-SpawnInterval=15
-SetPatrol=True
-ConditionPlayerWithinDistance=20
-ConditionMaxCloseCreatures=2
-ConditionMaxCreatures=100
+SpawnInterval=180
+SetPatrol=False
+ConditionPlayerWithinDistance=35
+ConditionMaxCloseCreatures=1
+ConditionMaxCreatures=12
 DistanceConsideredClose=20
 DistanceConsideredFar=1000
 OnGroundOnly=False
@@ -79,11 +79,11 @@ SpawnWeight=0.2
 IdentifyByName=BonePileSpawner
 IdentifyByBiome=Swamp
 LevelUpChance=15
-SpawnInterval=15
-SetPatrol=True
-ConditionPlayerWithinDistance=20
-ConditionMaxCloseCreatures=2
-ConditionMaxCreatures=100
+SpawnInterval=180
+SetPatrol=False
+ConditionPlayerWithinDistance=35
+ConditionMaxCloseCreatures=1
+ConditionMaxCreatures=12
 DistanceConsideredClose=20
 DistanceConsideredFar=1000
 OnGroundOnly=False
@@ -104,18 +104,18 @@ SpawnWeight=1
 Enabled=True
 TemplateEnabled=True
 PrefabName=SkeletonMage_TW
-SpawnWeight=0.2
+SpawnWeight=0.05
 
 ####################
 
 [Spawner_DraugrPile]
 IdentifyByName=Spawner_DraugrPile
 LevelUpChance=15
-SpawnInterval=15
-SetPatrol=True
-ConditionPlayerWithinDistance=20
-ConditionMaxCloseCreatures=3
-ConditionMaxCreatures=100
+SpawnInterval=180
+SetPatrol=False
+ConditionPlayerWithinDistance=35
+ConditionMaxCloseCreatures=1
+ConditionMaxCreatures=12
 DistanceConsideredClose=20
 DistanceConsideredFar=1000
 OnGroundOnly=False
@@ -124,19 +124,19 @@ OnGroundOnly=False
 Enabled=True
 TemplateEnabled=True
 PrefabName=Draugr
-SpawnWeight=4
+SpawnWeight=3.0
 
 [Spawner_DraugrPile.1]
 Enabled=True
 TemplateEnabled=True
 PrefabName=Draugr_Ranged
-SpawnWeight=4
+SpawnWeight=1.5
 
 [Spawner_DraugrPile.2]
 Enabled=True
 TemplateEnabled=True
 PrefabName=Draugr_Elite
-SpawnWeight=1
+SpawnWeight=0.5
 
 [Spawner_DraugrPile.3]
 Enabled=True

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/_RelicHeimFiles/Drop,Spawn_That/spawn_that.spawnarea_spawners.PilesNests.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/_RelicHeimFiles/Drop,Spawn_That/spawn_that.spawnarea_spawners.PilesNests.cfg
@@ -44,11 +44,11 @@ SpawnWeight=0.2
 IdentifyByName=BonePileSpawner
 IdentifyByBiome=BlackForest
 LevelUpChance=15
-SpawnInterval=15
-SetPatrol=True
-ConditionPlayerWithinDistance=20
-ConditionMaxCloseCreatures=2
-ConditionMaxCreatures=100
+SpawnInterval=180
+SetPatrol=False
+ConditionPlayerWithinDistance=35
+ConditionMaxCloseCreatures=1
+ConditionMaxCreatures=12
 DistanceConsideredClose=20
 DistanceConsideredFar=1000
 OnGroundOnly=False
@@ -79,11 +79,11 @@ SpawnWeight=0.2
 IdentifyByName=BonePileSpawner
 IdentifyByBiome=Swamp
 LevelUpChance=15
-SpawnInterval=15
-SetPatrol=True
-ConditionPlayerWithinDistance=20
-ConditionMaxCloseCreatures=2
-ConditionMaxCreatures=100
+SpawnInterval=180
+SetPatrol=False
+ConditionPlayerWithinDistance=35
+ConditionMaxCloseCreatures=1
+ConditionMaxCreatures=12
 DistanceConsideredClose=20
 DistanceConsideredFar=1000
 OnGroundOnly=False
@@ -104,18 +104,18 @@ SpawnWeight=1
 Enabled=True
 TemplateEnabled=True
 PrefabName=SkeletonMage_TW
-SpawnWeight=0.2
+SpawnWeight=0.05
 
 ####################
 
 [Spawner_DraugrPile]
 IdentifyByName=Spawner_DraugrPile
 LevelUpChance=15
-SpawnInterval=15
-SetPatrol=True
-ConditionPlayerWithinDistance=20
-ConditionMaxCloseCreatures=3
-ConditionMaxCreatures=100
+SpawnInterval=180
+SetPatrol=False
+ConditionPlayerWithinDistance=35
+ConditionMaxCloseCreatures=1
+ConditionMaxCreatures=12
 DistanceConsideredClose=20
 DistanceConsideredFar=1000
 OnGroundOnly=False
@@ -124,19 +124,19 @@ OnGroundOnly=False
 Enabled=True
 TemplateEnabled=True
 PrefabName=Draugr
-SpawnWeight=4
+SpawnWeight=3.0
 
 [Spawner_DraugrPile.1]
 Enabled=True
 TemplateEnabled=True
 PrefabName=Draugr_Ranged
-SpawnWeight=4
+SpawnWeight=1.5
 
 [Spawner_DraugrPile.2]
 Enabled=True
 TemplateEnabled=True
 PrefabName=Draugr_Elite
-SpawnWeight=1
+SpawnWeight=0.5
 
 [Spawner_DraugrPile.3]
 Enabled=True

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/_RelicHeimFiles/Drop,Spawn_That/spawn_that.spawnarea_spawners.PilesNests.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/_RelicHeimFiles/Drop,Spawn_That/spawn_that.spawnarea_spawners.PilesNests.cfg
@@ -44,11 +44,11 @@ SpawnWeight=0.2
 IdentifyByName=BonePileSpawner
 IdentifyByBiome=BlackForest
 LevelUpChance=15
-SpawnInterval=15
-SetPatrol=True
-ConditionPlayerWithinDistance=20
-ConditionMaxCloseCreatures=2
-ConditionMaxCreatures=100
+SpawnInterval=180
+SetPatrol=False
+ConditionPlayerWithinDistance=35
+ConditionMaxCloseCreatures=1
+ConditionMaxCreatures=12
 DistanceConsideredClose=20
 DistanceConsideredFar=1000
 OnGroundOnly=False
@@ -79,11 +79,11 @@ SpawnWeight=0.2
 IdentifyByName=BonePileSpawner
 IdentifyByBiome=Swamp
 LevelUpChance=15
-SpawnInterval=15
-SetPatrol=True
-ConditionPlayerWithinDistance=20
-ConditionMaxCloseCreatures=2
-ConditionMaxCreatures=100
+SpawnInterval=180
+SetPatrol=False
+ConditionPlayerWithinDistance=35
+ConditionMaxCloseCreatures=1
+ConditionMaxCreatures=12
 DistanceConsideredClose=20
 DistanceConsideredFar=1000
 OnGroundOnly=False
@@ -104,18 +104,18 @@ SpawnWeight=1
 Enabled=True
 TemplateEnabled=True
 PrefabName=SkeletonMage_TW
-SpawnWeight=0.2
+SpawnWeight=0.05
 
 ####################
 
 [Spawner_DraugrPile]
 IdentifyByName=Spawner_DraugrPile
 LevelUpChance=15
-SpawnInterval=15
-SetPatrol=True
-ConditionPlayerWithinDistance=20
-ConditionMaxCloseCreatures=3
-ConditionMaxCreatures=100
+SpawnInterval=180
+SetPatrol=False
+ConditionPlayerWithinDistance=35
+ConditionMaxCloseCreatures=1
+ConditionMaxCreatures=12
 DistanceConsideredClose=20
 DistanceConsideredFar=1000
 OnGroundOnly=False
@@ -124,19 +124,19 @@ OnGroundOnly=False
 Enabled=True
 TemplateEnabled=True
 PrefabName=Draugr
-SpawnWeight=4
+SpawnWeight=3.0
 
 [Spawner_DraugrPile.1]
 Enabled=True
 TemplateEnabled=True
 PrefabName=Draugr_Ranged
-SpawnWeight=4
+SpawnWeight=1.5
 
 [Spawner_DraugrPile.2]
 Enabled=True
 TemplateEnabled=True
 PrefabName=Draugr_Elite
-SpawnWeight=1
+SpawnWeight=0.5
 
 [Spawner_DraugrPile.3]
 Enabled=True

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/_RelicHeimFiles/Drop,Spawn_That/spawn_that.spawnarea_spawners.PilesNests.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/_RelicHeimFiles/Drop,Spawn_That/spawn_that.spawnarea_spawners.PilesNests.cfg
@@ -44,11 +44,11 @@ SpawnWeight=0.2
 IdentifyByName=BonePileSpawner
 IdentifyByBiome=BlackForest
 LevelUpChance=15
-SpawnInterval=120
-SetPatrol=True
-ConditionPlayerWithinDistance=30
+SpawnInterval=180
+SetPatrol=False
+ConditionPlayerWithinDistance=35
 ConditionMaxCloseCreatures=1
-ConditionMaxCreatures=40
+ConditionMaxCreatures=12
 DistanceConsideredClose=20
 DistanceConsideredFar=1000
 OnGroundOnly=False
@@ -79,11 +79,11 @@ SpawnWeight=0.2
 IdentifyByName=BonePileSpawner
 IdentifyByBiome=Swamp
 LevelUpChance=15
-SpawnInterval=120
-SetPatrol=True
-ConditionPlayerWithinDistance=30
+SpawnInterval=180
+SetPatrol=False
+ConditionPlayerWithinDistance=35
 ConditionMaxCloseCreatures=1
-ConditionMaxCreatures=40
+ConditionMaxCreatures=12
 DistanceConsideredClose=20
 DistanceConsideredFar=1000
 OnGroundOnly=False
@@ -104,18 +104,18 @@ SpawnWeight=1
 Enabled=True
 TemplateEnabled=True
 PrefabName=SkeletonMage_TW
-SpawnWeight=0.2
+SpawnWeight=0.05
 
 ####################
 
 [Spawner_DraugrPile]
 IdentifyByName=Spawner_DraugrPile
 LevelUpChance=15
-SpawnInterval=120
-SetPatrol=True
-ConditionPlayerWithinDistance=30
+SpawnInterval=180
+SetPatrol=False
+ConditionPlayerWithinDistance=35
 ConditionMaxCloseCreatures=1
-ConditionMaxCreatures=40
+ConditionMaxCreatures=12
 DistanceConsideredClose=20
 DistanceConsideredFar=1000
 OnGroundOnly=False
@@ -124,19 +124,19 @@ OnGroundOnly=False
 Enabled=True
 TemplateEnabled=True
 PrefabName=Draugr
-SpawnWeight=3.5
+SpawnWeight=3.0
 
 [Spawner_DraugrPile.1]
 Enabled=True
 TemplateEnabled=True
 PrefabName=Draugr_Ranged
-SpawnWeight=2.5
+SpawnWeight=1.5
 
 [Spawner_DraugrPile.2]
 Enabled=True
 TemplateEnabled=True
 PrefabName=Draugr_Elite
-SpawnWeight=0.8
+SpawnWeight=0.5
 
 [Spawner_DraugrPile.3]
 Enabled=True

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/_RelicHeimFiles/Drop,Spawn_That/spawn_that.spawnarea_spawners.PilesNests.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/_RelicHeimFiles/Drop,Spawn_That/spawn_that.spawnarea_spawners.PilesNests.cfg
@@ -79,11 +79,11 @@ SpawnWeight=0.2
 IdentifyByName=BonePileSpawner
 IdentifyByBiome=Swamp
 LevelUpChance=15
-SpawnInterval=120
-SetPatrol=True
-ConditionPlayerWithinDistance=30
+SpawnInterval=180
+SetPatrol=False
+ConditionPlayerWithinDistance=35
 ConditionMaxCloseCreatures=1
-ConditionMaxCreatures=40
+ConditionMaxCreatures=12
 DistanceConsideredClose=20
 DistanceConsideredFar=1000
 OnGroundOnly=False
@@ -104,18 +104,18 @@ SpawnWeight=1
 Enabled=True
 TemplateEnabled=True
 PrefabName=SkeletonMage_TW
-SpawnWeight=0.2
+SpawnWeight=0.05
 
 ####################
 
 [Spawner_DraugrPile]
 IdentifyByName=Spawner_DraugrPile
 LevelUpChance=15
-SpawnInterval=120
-SetPatrol=True
-ConditionPlayerWithinDistance=30
+SpawnInterval=180
+SetPatrol=False
+ConditionPlayerWithinDistance=35
 ConditionMaxCloseCreatures=1
-ConditionMaxCreatures=40
+ConditionMaxCreatures=12
 DistanceConsideredClose=20
 DistanceConsideredFar=1000
 OnGroundOnly=False
@@ -124,19 +124,19 @@ OnGroundOnly=False
 Enabled=True
 TemplateEnabled=True
 PrefabName=Draugr
-SpawnWeight=3.5
+SpawnWeight=3.0
 
 [Spawner_DraugrPile.1]
 Enabled=True
 TemplateEnabled=True
 PrefabName=Draugr_Ranged
-SpawnWeight=2.5
+SpawnWeight=1.5
 
 [Spawner_DraugrPile.2]
 Enabled=True
 TemplateEnabled=True
 PrefabName=Draugr_Elite
-SpawnWeight=0.8
+SpawnWeight=0.5
 
 [Spawner_DraugrPile.3]
 Enabled=True


### PR DESCRIPTION
## Summary
- slow down bone and draugr pile spawning
- reduce ranged and mage spawn weights

## Testing
- `python -m py_compile scripts/config_change_tracker.py`


------
https://chatgpt.com/codex/tasks/task_e_689f48e967508331993e7377e8fd7584