### PR TITLE
Restore RelicHeim raid settings

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/custom_raids.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/custom_raids.cfg
@@ -56,13 +56,13 @@ OverrideExisting = true
 ## When the interval has passed, all raids are checked for valid conditions and a random valid one is selected. Chance is then rolled for if it should start.
 # Setting type: Single
 # Default value: 46
-EventCheckInterval = 90
+EventCheckInterval = 60
 
 ## Chance of raid, per check interval. 100 is 100%.
 ## Note: Not used if UseIndividualRaidChecks is enabled, each raid will have their own chance in that case.
 # Setting type: Single
 # Default value: 20
-EventTriggerChance = 25
+EventTriggerChance = 40
 
 [General]
 


### PR DESCRIPTION
## Summary
- Restore base raid settings using RelicHeim backup
- EventCheckInterval set to 60 minutes
- EventTriggerChance set to 40%

## Testing
- `python -m py_compile scripts/config_change_tracker.py scripts/item_skill_tracker.py`


------
https://chatgpt.com/codex/tasks/task_e_689f8d2673a08331b05f45272b4b5b89