### PR TITLE
Tune raid frequency

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/custom_raids.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/custom_raids.cfg
@@ -56,13 +56,13 @@ OverrideExisting = true
 ## When the interval has passed, all raids are checked for valid conditions and a random valid one is selected. Chance is then rolled for if it should start.
 # Setting type: Single
 # Default value: 46
-EventCheckInterval = 60
+EventCheckInterval = 90
 
 ## Chance of raid, per check interval. 100 is 100%.
 ## Note: Not used if UseIndividualRaidChecks is enabled, each raid will have their own chance in that case.
 # Setting type: Single
 # Default value: 20
-EventTriggerChance = 40
+EventTriggerChance = 20
 
 [General]
 


### PR DESCRIPTION
## Summary
- Reduce chance of a raid occurring and increase time between raid checks
- Confirm custom raids remain enabled

## Testing
- `python -m py_compile $(git ls-files '*.py') && echo "py_compile passed"`


------
https://chatgpt.com/codex/tasks/task_e_689f9c4fe6b08331887349ac980c1d58