### PR TITLE
Enable non-combat XP gains

### DIFF
--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/WackyMole.EpicMMOSystem.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/WackyMole.EpicMMOSystem.cfg
@@ -502,7 +502,7 @@ Use Regular Fermentor = true
 ## Disables all non combat xp. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-1.Disable All NonCombat XP = true
+1.Disable All NonCombat XP = false
 
 ## Disables Piece XP. You only get xp for once per building, then you have to change to another piece. It still could be abused. [Synced with Server]
 # Setting type: Boolean

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/WackyMole.EpicMMOSystem.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/WackyMole.EpicMMOSystem.cfg
@@ -502,7 +502,7 @@ Use Regular Fermentor = true
 ## Disables all non combat xp. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-1.Disable All NonCombat XP = true
+1.Disable All NonCombat XP = false
 
 ## Disables Piece XP. You only get xp for once per building, then you have to change to another piece. It still could be abused. [Synced with Server]
 # Setting type: Boolean

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/WackyMole.EpicMMOSystem.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/WackyMole.EpicMMOSystem.cfg
@@ -502,7 +502,7 @@ Use Regular Fermentor = true
 ## Disables all non combat xp. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-1.Disable All NonCombat XP = true
+1.Disable All NonCombat XP = false
 
 ## Disables Piece XP. You only get xp for once per building, then you have to change to another piece. It still could be abused. [Synced with Server]
 # Setting type: Boolean

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/WackyMole.EpicMMOSystem.cfg
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/WackyMole.EpicMMOSystem.cfg
@@ -502,22 +502,22 @@ Use Regular Fermentor = true
 ## Disables all non combat xp. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-1.Disable All NonCombat XP = true
+1.Disable All NonCombat XP = false
 
 ## Disables Piece XP. You only get xp for once per building, then you have to change to another piece. It still could be abused. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-Disable Piece XP = true
+Disable Piece XP = false
 
 ## Disables XP for tames. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-Disable Tame XP = true
+Disable Tame XP = false
 
 ## Disable Fish pickup XP, you still get xp for catching fish. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-Disable Fish Pickup XP = true
+Disable Fish Pickup XP = false
 
 ## Disable XP for mining. [Synced with Server]
 # Setting type: Boolean
@@ -527,7 +527,7 @@ Disable Mining XP = false
 ## Disable XP for pickables. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-Disable Pickup XP = true
+Disable Pickup XP = false
 
 ## Disable XP for Chopping Trees. [Synced with Server]
 # Setting type: Boolean
@@ -537,7 +537,7 @@ Disable Tree XP = false
 ## Disable XP Destructables. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-Disable Destructables XP = true
+Disable Destructables XP = false
 
 ## Gives a Warning log for various objects names. Don't forgot that (Clone) is added to everything in the jsons. [Not Synced with Server]
 # Setting type: Boolean

--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.EpicMMOSystem.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/WackyMole.EpicMMOSystem.cfg
@@ -502,22 +502,22 @@ Use Regular Fermentor = true
 ## Disables all non combat xp. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-1.Disable All NonCombat XP = true
+1.Disable All NonCombat XP = false
 
 ## Disables Piece XP. You only get xp for once per building, then you have to change to another piece. It still could be abused. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-Disable Piece XP = true
+Disable Piece XP = false
 
 ## Disables XP for tames. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-Disable Tame XP = true
+Disable Tame XP = false
 
 ## Disable Fish pickup XP, you still get xp for catching fish. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-Disable Fish Pickup XP = true
+Disable Fish Pickup XP = false
 
 ## Disable XP for mining. [Synced with Server]
 # Setting type: Boolean
@@ -527,7 +527,7 @@ Disable Mining XP = false
 ## Disable XP for pickables. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-Disable Pickup XP = true
+Disable Pickup XP = false
 
 ## Disable XP for Chopping Trees. [Synced with Server]
 # Setting type: Boolean
@@ -537,7 +537,7 @@ Disable Tree XP = false
 ## Disable XP Destructables. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-Disable Destructables XP = true
+Disable Destructables XP = false
 
 ## Gives a Warning log for various objects names. Don't forgot that (Clone) is added to everything in the jsons. [Not Synced with Server]
 # Setting type: Boolean

--- a/Valheim_Help_Docs/JewelHeim-RelicHeim-5.4.10Backup/config/BACKUP_5.4.10_WackyMole.EpicMMOSystem.cfg
+++ b/Valheim_Help_Docs/JewelHeim-RelicHeim-5.4.10Backup/config/BACKUP_5.4.10_WackyMole.EpicMMOSystem.cfg
@@ -502,7 +502,7 @@ Use Regular Fermentor = true
 ## Disables all non combat xp. [Synced with Server]
 # Setting type: Boolean
 # Default value: false
-1.Disable All NonCombat XP = true
+1.Disable All NonCombat XP = false
 
 ## Disables Piece XP. You only get xp for once per building, then you have to change to another piece. It still could be abused. [Synced with Server]
 # Setting type: Boolean


### PR DESCRIPTION
## Summary
- Allow non-combat experience by disabling all non-combat XP restrictions in EpicMMOSystem configs

## Testing
- `python -m py_compile scripts/config_change_tracker.py scripts/item_skill_tracker.py`


------
https://chatgpt.com/codex/tasks/task_e_689fb9b6f4bc8331a1e0ed8ac333841d