### PR TITLE
Enable workbench crafting for explorers backpack and hide backpack

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.backpacks.cfg
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/org.bepinex.plugins.backpacks.cfg
@@ -80,7 +80,7 @@ Unique Backpack = Global
 # Setting type: Toggle
 # Default value: Off
 # Acceptable values: Off, On
-Hide Backpack = Off
+Hide Backpack = On
 
 ## If on, the backpack in your backpack slot is opened automatically, if the inventory is opened.
 # Setting type: Toggle
@@ -111,7 +111,7 @@ Backpack Slot = On
 # Setting type: CraftingTable
 # Default value: Workbench
 # Acceptable values: Disabled, Inventory, Workbench, Cauldron, Forge, ArtisanTable, StoneCutter, MageTable, BlackForge, FoodPreparationTable, MeadKetill, Custom
-Crafting Station = Disabled
+Crafting Station = Workbench
 
 # Setting type: String
 # Default value: 


### PR DESCRIPTION
## Summary
- enable workbench as crafting station for explorers backpack
- hide backpack so it is not shown

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fb9657cb08331ae971b486cddb80e