### PR TITLE
Increase stack sizes for bones, hides, and trophies

### DIFF
--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/ItemConfig_Base.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.6/config/ItemConfig_Base.yml
@@ -69,6 +69,53 @@ groups:
   - RagnoriteOre_TW
   - TyraniumOre_TW
   - LokvyrOre_TW
+  Stackable:
+  - BoneFragments
+  - CryptKey
+  - DeerHide
+  - LeatherScraps
+  - TrollHide
+  - WolfPelt
+  - LoxPelt
+  - GreydwarfEye
+  - Resin
+  - TrophyBoar
+  - TrophyDeer
+  - TrophyNeck
+  - TrophyGreydwarf
+  - TrophyGreydwarfShaman
+  - TrophyGreydwarfBrute
+  - TrophyGreydwarfElite
+  - TrophyTroll
+  - TrophySkeleton
+  - TrophyDraugr
+  - TrophyDraugrElite
+  - TrophyLeech
+  - TrophyBlob
+  - TrophyWraith
+  - TrophySurtling
+  - TrophyLox
+  - TrophySerpent
+  - TrophyDrake
+  - TrophyWolf
+  - TrophyFenring
+  - TrophyUlv
+  - TrophyCultist
+  - TrophySGolem
+  - TrophyAbomination
+  - TrophyBonemass
+  - TrophyEikthyr
+  - TrophyTheElder
+  - TrophyModer
+  - TrophyYagluth
+  - TrophySeeker
+  - TrophySeekerBrute
+  - TrophySeekerQueen
+  - TrophyGjall
+  - TrophyTick
+  - TrophyDverger
+  - TrophyDvergerMage
+  - TrophyDvergerRogue
 #
 all:
     floating: yes
@@ -84,7 +131,7 @@ HoneyGlazedNeck:
 Stackable:
     stack: 200
 WizardryScrolls:
-    stack: 10
+    stack: 200
 DragonEgg:
     stack: 3
     weight: 100
@@ -92,7 +139,7 @@ SurtrDrakeEgg_TW:
     teleportable: yes
     weight: 100
 CryptKey:
-    stack: 10
+    stack: 200
 MeadBase:
     stack: 100
 mmo_mead_minor:

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/ItemConfig_Base.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.7/config/ItemConfig_Base.yml
@@ -69,6 +69,53 @@ groups:
   - RagnoriteOre_TW
   - TyraniumOre_TW
   - LokvyrOre_TW
+  Stackable:
+  - BoneFragments
+  - CryptKey
+  - DeerHide
+  - LeatherScraps
+  - TrollHide
+  - WolfPelt
+  - LoxPelt
+  - GreydwarfEye
+  - Resin
+  - TrophyBoar
+  - TrophyDeer
+  - TrophyNeck
+  - TrophyGreydwarf
+  - TrophyGreydwarfShaman
+  - TrophyGreydwarfBrute
+  - TrophyGreydwarfElite
+  - TrophyTroll
+  - TrophySkeleton
+  - TrophyDraugr
+  - TrophyDraugrElite
+  - TrophyLeech
+  - TrophyBlob
+  - TrophyWraith
+  - TrophySurtling
+  - TrophyLox
+  - TrophySerpent
+  - TrophyDrake
+  - TrophyWolf
+  - TrophyFenring
+  - TrophyUlv
+  - TrophyCultist
+  - TrophySGolem
+  - TrophyAbomination
+  - TrophyBonemass
+  - TrophyEikthyr
+  - TrophyTheElder
+  - TrophyModer
+  - TrophyYagluth
+  - TrophySeeker
+  - TrophySeekerBrute
+  - TrophySeekerQueen
+  - TrophyGjall
+  - TrophyTick
+  - TrophyDverger
+  - TrophyDvergerMage
+  - TrophyDvergerRogue
 #
 all:
     floating: yes
@@ -84,7 +131,7 @@ HoneyGlazedNeck:
 Stackable:
     stack: 200
 WizardryScrolls:
-    stack: 10
+    stack: 200
 DragonEgg:
     stack: 3
     weight: 100
@@ -92,7 +139,7 @@ SurtrDrakeEgg_TW:
     teleportable: yes
     weight: 100
 CryptKey:
-    stack: 10
+    stack: 200
 MeadBase:
     stack: 100
 mmo_mead_minor:

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/ItemConfig_Base.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.8/config/ItemConfig_Base.yml
@@ -69,6 +69,53 @@ groups:
   - RagnoriteOre_TW
   - TyraniumOre_TW
   - LokvyrOre_TW
+  Stackable:
+  - BoneFragments
+  - CryptKey
+  - DeerHide
+  - LeatherScraps
+  - TrollHide
+  - WolfPelt
+  - LoxPelt
+  - GreydwarfEye
+  - Resin
+  - TrophyBoar
+  - TrophyDeer
+  - TrophyNeck
+  - TrophyGreydwarf
+  - TrophyGreydwarfShaman
+  - TrophyGreydwarfBrute
+  - TrophyGreydwarfElite
+  - TrophyTroll
+  - TrophySkeleton
+  - TrophyDraugr
+  - TrophyDraugrElite
+  - TrophyLeech
+  - TrophyBlob
+  - TrophyWraith
+  - TrophySurtling
+  - TrophyLox
+  - TrophySerpent
+  - TrophyDrake
+  - TrophyWolf
+  - TrophyFenring
+  - TrophyUlv
+  - TrophyCultist
+  - TrophySGolem
+  - TrophyAbomination
+  - TrophyBonemass
+  - TrophyEikthyr
+  - TrophyTheElder
+  - TrophyModer
+  - TrophyYagluth
+  - TrophySeeker
+  - TrophySeekerBrute
+  - TrophySeekerQueen
+  - TrophyGjall
+  - TrophyTick
+  - TrophyDverger
+  - TrophyDvergerMage
+  - TrophyDvergerRogue
 #
 all:
     floating: yes
@@ -84,7 +131,7 @@ HoneyGlazedNeck:
 Stackable:
     stack: 200
 WizardryScrolls:
-    stack: 10
+    stack: 200
 DragonEgg:
     stack: 3
     weight: 100
@@ -92,7 +139,7 @@ SurtrDrakeEgg_TW:
     teleportable: yes
     weight: 100
 CryptKey:
-    stack: 10
+    stack: 200
 MeadBase:
     stack: 100
 mmo_mead_minor:

--- a/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/ItemConfig_Base.yml
+++ b/Valheim/cache/JewelHeim-RelicHeim/5.4.9/config/ItemConfig_Base.yml
@@ -69,6 +69,53 @@ groups:
   - RagnoriteOre_TW
   - TyraniumOre_TW
   - LokvyrOre_TW
+  Stackable:
+  - BoneFragments
+  - CryptKey
+  - DeerHide
+  - LeatherScraps
+  - TrollHide
+  - WolfPelt
+  - LoxPelt
+  - GreydwarfEye
+  - Resin
+  - TrophyBoar
+  - TrophyDeer
+  - TrophyNeck
+  - TrophyGreydwarf
+  - TrophyGreydwarfShaman
+  - TrophyGreydwarfBrute
+  - TrophyGreydwarfElite
+  - TrophyTroll
+  - TrophySkeleton
+  - TrophyDraugr
+  - TrophyDraugrElite
+  - TrophyLeech
+  - TrophyBlob
+  - TrophyWraith
+  - TrophySurtling
+  - TrophyLox
+  - TrophySerpent
+  - TrophyDrake
+  - TrophyWolf
+  - TrophyFenring
+  - TrophyUlv
+  - TrophyCultist
+  - TrophySGolem
+  - TrophyAbomination
+  - TrophyBonemass
+  - TrophyEikthyr
+  - TrophyTheElder
+  - TrophyModer
+  - TrophyYagluth
+  - TrophySeeker
+  - TrophySeekerBrute
+  - TrophySeekerQueen
+  - TrophyGjall
+  - TrophyTick
+  - TrophyDverger
+  - TrophyDvergerMage
+  - TrophyDvergerRogue
 #
 all:
     floating: yes
@@ -84,7 +131,7 @@ HoneyGlazedNeck:
 Stackable:
     stack: 200
 WizardryScrolls:
-    stack: 10
+    stack: 200
 DragonEgg:
     stack: 3
     weight: 100
@@ -92,7 +139,7 @@ SurtrDrakeEgg_TW:
     teleportable: yes
     weight: 100
 CryptKey:
-    stack: 10
+    stack: 200
 MeadBase:
     stack: 100
 mmo_mead_minor:


### PR DESCRIPTION
## Summary
- Group common materials and trophies under a new `Stackable` list
- Allow Wizardry scrolls, CryptKeys, and grouped items to stack up to 200

## Testing
- `rg -n "CryptKey:\n\s*stack: 200" -U Valheim/cache/JewelHeim-RelicHeim/5.4.*/config/ItemConfig_Base.yml`
- `rg -n "WizardryScrolls:\n\s*stack: 200" -U Valheim/cache/JewelHeim-RelicHeim/5.4.*/config/ItemConfig_Base.yml`


------
https://chatgpt.com/codex/tasks/task_e_689fc23c864c8331b9347250d0990b38