### PR TITLE
Boost fishing skill XP

### DIFF
--- a/Valheim/profiles/Dogeheim_Player/BepInEx/config/shudnal.Seasons/Default settings/Custom stats.json
+++ b/Valheim/profiles/Dogeheim_Player/BepInEx/config/shudnal.Seasons/Default settings/Custom stats.json
@@ -78,7 +78,7 @@
     "m_eitrRegenMultiplier": 1.1,
     "m_raiseSkills": {
       "WoodCutting": 1.2,
-      "Fishing": 1.2,
+      "Fishing": 1.4,
       "Pickaxes": 1.2
     },
     "m_skillLevels": {
@@ -108,7 +108,7 @@
     "m_eitrRegenMultiplier": 1.0,
     "m_raiseSkills": {
       "WoodCutting": 1.1,
-      "Fishing": 1.1,
+      "Fishing": 1.3,
       "Pickaxes": 1.1
     },
     "m_skillLevels": {


### PR DESCRIPTION
## Summary
- increase fishing skill gain in Fall to 1.4
- increase fishing skill gain in Winter to 1.3

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fdcc01264833185712f403c7940af